### PR TITLE
Fix ReactiveTransaction import in JpaConfig

### DIFF
--- a/src/main/java/com/credibanco/authorizer_catalog_bin_manager_cf/infrastructure/config/JpaConfig.java
+++ b/src/main/java/com/credibanco/authorizer_catalog_bin_manager_cf/infrastructure/config/JpaConfig.java
@@ -19,7 +19,7 @@ import org.springframework.transaction.PlatformTransactionManager;
 import org.springframework.transaction.ReactiveTransactionManager;
 import org.springframework.transaction.TransactionDefinition;
 import org.springframework.transaction.TransactionStatus;
-import org.springframework.transaction.reactive.ReactiveTransaction;
+import org.springframework.transaction.ReactiveTransaction;
 import org.springframework.transaction.reactive.TransactionalOperator;
 import org.springframework.transaction.support.DefaultTransactionDefinition;
 import org.springframework.util.Assert;


### PR DESCRIPTION
## Summary
- replace the deprecated reactive ReactiveTransaction import with the new org.springframework.transaction.ReactiveTransaction in JpaConfig

## Testing
- mvn -q -DskipTests package *(fails: Non-resolvable parent POM: 403 from Maven Central)*

------
https://chatgpt.com/codex/tasks/task_e_68e08b61de48832ea1b79b6c436a1d1a