### PR TITLE
Handle reactive transactions with dedicated worker

### DIFF
--- a/src/test/java/com/credibanco/authorizer_catalog_bin_manager_cf/application/bin/use_case/CreateBinServiceTest.java
+++ b/src/test/java/com/credibanco/authorizer_catalog_bin_manager_cf/application/bin/use_case/CreateBinServiceTest.java
@@ -1,0 +1,56 @@
+package com.credibanco.authorizer_catalog_bin_manager_cf.application.bin.use_case;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+import static org.mockito.Mockito.when;
+
+import com.credibanco.authorizer_catalog_bin_manager_cf.application.bin.port.outbound.BinRepository;
+import com.credibanco.authorizer_catalog_bin_manager_cf.infrastructure.config.JpaConfig;
+import com.credibanco.authorizer_catalog_bin_manager_cf.infrastructure.exception.AppException;
+import org.junit.jupiter.api.Test;
+import org.springframework.transaction.PlatformTransactionManager;
+import org.springframework.transaction.TransactionDefinition;
+import org.springframework.transaction.TransactionStatus;
+import org.springframework.transaction.reactive.TransactionalOperator;
+import org.springframework.transaction.support.DefaultTransactionStatus;
+import reactor.core.publisher.Mono;
+import reactor.test.StepVerifier;
+
+class CreateBinServiceTest {
+
+    @Test
+    void whenBinAlreadyExistsServiceEmitsAppException() {
+        BinRepository repo = mock(BinRepository.class);
+        PlatformTransactionManager platformTxManager = new PlatformTransactionManager() {
+            @Override
+            public TransactionStatus getTransaction(TransactionDefinition definition) {
+                return new DefaultTransactionStatus(null, true, true, false, true, null);
+            }
+
+            @Override
+            public void commit(TransactionStatus status) {
+                // no-op for test
+            }
+
+            @Override
+            public void rollback(TransactionStatus status) {
+                // no-op for test
+            }
+        };
+        TransactionalOperator operator = TransactionalOperator
+                .create(new JpaConfig.ReactivePlatformTransactionManagerAdapter(platformTxManager));
+        CreateBinService service = new CreateBinService(repo, operator);
+
+        String bin = "123456";
+        when(repo.existsById(bin)).thenReturn(Mono.just(true));
+
+        StepVerifier.create(service.execute(bin, "Test", "DEBITO", "01", "01", "desc", "N", null, "tester"))
+                .expectErrorSatisfies(error -> assertTrue(error instanceof AppException))
+                .verify();
+
+        verify(repo).existsById(bin);
+        verifyNoMoreInteractions(repo);
+    }
+}


### PR DESCRIPTION
## Summary
- create a dedicated scheduler worker per transaction in the reactive JPA transaction manager adapter
- run commit and rollback on the stored worker and dispose it once the operation completes
- add a CreateBinServiceTest that verifies an AppException is emitted when the BIN already exists

## Testing
- mvn test *(fails: Non-resolvable parent POM due to 403 Forbidden from Maven Central)*

------
https://chatgpt.com/codex/tasks/task_e_68e1692ceb04832e97b7dcf73e940de9