### PR TITLE
Handle missing BIN lookups gracefully in reactive adapters

### DIFF
--- a/src/main/java/com/credibanco/authorizer_catalog_bin_manager_cf/infrastructure/port/outbound/jpa/JpaBinRepository.java
+++ b/src/main/java/com/credibanco/authorizer_catalog_bin_manager_cf/infrastructure/port/outbound/jpa/JpaBinRepository.java
@@ -16,7 +16,6 @@ import reactor.core.publisher.Mono;
 import reactor.core.scheduler.Schedulers;
 
 import java.util.List;
-import java.util.NoSuchElementException;
 import java.util.Objects;
 
 @Repository
@@ -50,8 +49,8 @@ public class JpaBinRepository implements BinRepository, BinReadOnlyRepository {
     @Override
     public Mono<Bin> findById(String bin) {
         return Mono.defer(() -> Mono.fromCallable(() -> repository.findById(bin)
-                        .map(BinJpaMapper::toDomain)
-                        .orElseThrow(() -> new NoSuchElementException("BIN not found: " + bin))))
+                        .map(BinJpaMapper::toDomain)))
+                .flatMap(Mono::justOrEmpty)
                 .subscribeOn(Schedulers.boundedElastic());
     }
 
@@ -72,8 +71,8 @@ public class JpaBinRepository implements BinRepository, BinReadOnlyRepository {
     @Override
     public Mono<BinExtConfig> getExtConfig(String bin) {
         return Mono.defer(() -> Mono.fromCallable(() -> repository.findById(bin)
-                        .map(e -> new BinExtConfig(e.getUsesBinExt(), e.getBinExtDigits()))
-                        .orElseThrow(() -> new NoSuchElementException("BIN not found: " + bin))))
+                        .map(e -> new BinExtConfig(e.getUsesBinExt(), e.getBinExtDigits()))))
+                .flatMap(Mono::justOrEmpty)
                 .subscribeOn(Schedulers.boundedElastic());
     }
 }

--- a/src/test/java/com/credibanco/authorizer_catalog_bin_manager_cf/application/bin/use_case/UpdateBinServiceTest.java
+++ b/src/test/java/com/credibanco/authorizer_catalog_bin_manager_cf/application/bin/use_case/UpdateBinServiceTest.java
@@ -1,0 +1,51 @@
+package com.credibanco.authorizer_catalog_bin_manager_cf.application.bin.use_case;
+
+import com.credibanco.authorizer_catalog_bin_manager_cf.application.bin.port.outbound.BinRepository;
+import com.credibanco.authorizer_catalog_bin_manager_cf.infrastructure.exception.AppError;
+import com.credibanco.authorizer_catalog_bin_manager_cf.infrastructure.exception.AppException;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+import org.springframework.transaction.reactive.TransactionalOperator;
+import reactor.core.publisher.Mono;
+import reactor.test.StepVerifier;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+class UpdateBinServiceTest {
+
+    private BinRepository binRepository;
+    private TransactionalOperator txOperator;
+    private UpdateBinService service;
+
+    @BeforeEach
+    void setUp() {
+        binRepository = mock(BinRepository.class);
+        txOperator = mock(TransactionalOperator.class);
+        service = new UpdateBinService(binRepository, txOperator);
+
+        when(txOperator.transactional(any(Mono.class)))
+                .thenAnswer(invocation -> invocation.getArgument(0));
+    }
+
+    @Test
+    void whenBinMissingReturnBinNotFoundError() {
+        String bin = "123456";
+        when(binRepository.findById(bin)).thenReturn(Mono.empty());
+
+        StepVerifier.create(service.execute(bin, "name", "type", "account",
+                        "compensation", "desc", "N", null, "user"))
+                .expectErrorSatisfies(error -> {
+                    assertTrue(error instanceof AppException);
+                    assertEquals(AppError.BIN_NOT_FOUND, ((AppException) error).getError());
+                })
+                .verify();
+
+        Mockito.verify(binRepository).findById(bin);
+        Mockito.verifyNoMoreInteractions(binRepository);
+    }
+}

--- a/src/test/java/com/credibanco/authorizer_catalog_bin_manager_cf/application/subtype/use_case/CreateSubtypeServiceTest.java
+++ b/src/test/java/com/credibanco/authorizer_catalog_bin_manager_cf/application/subtype/use_case/CreateSubtypeServiceTest.java
@@ -1,0 +1,58 @@
+package com.credibanco.authorizer_catalog_bin_manager_cf.application.subtype.use_case;
+
+import com.credibanco.authorizer_catalog_bin_manager_cf.application.subtype.port.outbound.BinReadOnlyRepository;
+import com.credibanco.authorizer_catalog_bin_manager_cf.application.subtype.port.outbound.IdTypeReadOnlyRepository;
+import com.credibanco.authorizer_catalog_bin_manager_cf.application.subtype.port.outbound.SubtypeRepository;
+import com.credibanco.authorizer_catalog_bin_manager_cf.infrastructure.exception.AppError;
+import com.credibanco.authorizer_catalog_bin_manager_cf.infrastructure.exception.AppException;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+import org.springframework.transaction.reactive.TransactionalOperator;
+import reactor.core.publisher.Mono;
+import reactor.test.StepVerifier;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+class CreateSubtypeServiceTest {
+
+    private SubtypeRepository subtypeRepository;
+    private BinReadOnlyRepository binRepository;
+    private IdTypeReadOnlyRepository idTypeRepository;
+    private TransactionalOperator txOperator;
+    private CreateSubtypeService service;
+
+    @BeforeEach
+    void setUp() {
+        subtypeRepository = mock(SubtypeRepository.class);
+        binRepository = mock(BinReadOnlyRepository.class);
+        idTypeRepository = mock(IdTypeReadOnlyRepository.class);
+        txOperator = mock(TransactionalOperator.class);
+
+        service = new CreateSubtypeService(subtypeRepository, binRepository, idTypeRepository, txOperator);
+
+        when(txOperator.transactional(any(Mono.class)))
+                .thenAnswer(invocation -> invocation.getArgument(0));
+    }
+
+    @Test
+    void whenBinConfigMissingReturnBinNotFoundError() {
+        String bin = "123456";
+        when(binRepository.getExtConfig(bin)).thenReturn(Mono.empty());
+
+        StepVerifier.create(service.execute("SUB", bin, "Subtype", "desc",
+                        null, null, null, "user"))
+                .expectErrorSatisfies(error -> {
+                    assertTrue(error instanceof AppException);
+                    assertEquals(AppError.BIN_NOT_FOUND, ((AppException) error).getError());
+                })
+                .verify();
+
+        Mockito.verify(binRepository).getExtConfig(bin);
+        Mockito.verifyNoMoreInteractions(binRepository, subtypeRepository, idTypeRepository);
+    }
+}


### PR DESCRIPTION
## Summary
- ensure the JPA-backed BIN repository returns empty Monos instead of throwing when lookups miss
- add regression tests that verify UpdateBinService and CreateSubtypeService surface BIN_NOT_FOUND when the repository is empty

## Testing
- `mvn -q -DskipTests test` *(fails: unable to resolve spring-boot-starter-parent 3.5.5 from Maven Central due to 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68e17880430c832e95abff87bbfd25b2