### PR TITLE
Update bearer token converter import

### DIFF
--- a/src/main/java/com/credibanco/authorizer_catalog_bin_manager_cf/infrastructure/config/security/SecurityConfig.java
+++ b/src/main/java/com/credibanco/authorizer_catalog_bin_manager_cf/infrastructure/config/security/SecurityConfig.java
@@ -22,7 +22,7 @@ import org.springframework.security.web.server.SecurityWebFilterChain;
 import org.springframework.security.web.server.authentication.AuthenticationWebFilter;
 import org.springframework.security.web.server.authentication.DelegatingServerAuthenticationConverter;
 import org.springframework.security.web.server.authentication.ServerAuthenticationConverter;
-import org.springframework.security.web.server.authentication.ServerBearerTokenAuthenticationConverter;
+import org.springframework.security.oauth2.server.resource.web.server.ServerBearerTokenAuthenticationConverter;
 import org.springframework.security.web.server.util.matcher.ServerWebExchangeMatchers;
 import org.springframework.util.StringUtils;
 import reactor.core.publisher.Mono;


### PR DESCRIPTION
## Summary
- update SecurityConfig to import ServerBearerTokenAuthenticationConverter from the Spring Security OAuth2 resource package

## Testing
- `mvn clean package` *(fails: unable to download org.springframework.boot:spring-boot-starter-parent:pom:3.5.5 due to 403 Forbidden from Maven Central)*

------
https://chatgpt.com/codex/tasks/task_e_68e1a1b79b14832e8314e86060a1c878