### PR TITLE
Update SecurityConfig bearer token converter import

### DIFF
--- a/src/main/java/com/credibanco/authorizer_catalog_bin_manager_cf/infrastructure/config/security/SecurityConfig.java
+++ b/src/main/java/com/credibanco/authorizer_catalog_bin_manager_cf/infrastructure/config/security/SecurityConfig.java
@@ -22,7 +22,7 @@ import org.springframework.security.web.server.SecurityWebFilterChain;
 import org.springframework.security.web.server.authentication.AuthenticationWebFilter;
 import org.springframework.security.web.server.authentication.DelegatingServerAuthenticationConverter;
 import org.springframework.security.web.server.authentication.ServerAuthenticationConverter;
-import org.springframework.security.oauth2.server.resource.web.server.ServerBearerTokenAuthenticationConverter;
+import org.springframework.security.oauth2.server.resource.authentication.ServerBearerTokenAuthenticationConverter;
 import org.springframework.security.web.server.util.matcher.ServerWebExchangeMatchers;
 import org.springframework.util.StringUtils;
 import reactor.core.publisher.Mono;


### PR DESCRIPTION
## Summary
- update the reactive security configuration to import the bearer token converter from the new authentication package

## Testing
- ⚠️ `mvn clean package` *(fails: unable to download parent POM due to 403 Forbidden from Maven Central)*

------
https://chatgpt.com/codex/tasks/task_e_68e1a356e758832e96488929e678e581