### PR TITLE
Add comprehensive tests for subtype layer

### DIFF
--- a/src/test/java/com/credibanco/authorizer_catalog_bin_manager_cf/application/subtype/use_case/ChangeSubtypeStatusServiceTest.java
+++ b/src/test/java/com/credibanco/authorizer_catalog_bin_manager_cf/application/subtype/use_case/ChangeSubtypeStatusServiceTest.java
@@ -1,0 +1,125 @@
+package com.credibanco.authorizer_catalog_bin_manager_cf.application.subtype.use_case;
+
+import com.credibanco.authorizer_catalog_bin_manager_cf.application.subtype.port.outbound.AgencyReadOnlyRepository;
+import com.credibanco.authorizer_catalog_bin_manager_cf.application.subtype.port.outbound.SubtypeRepository;
+import com.credibanco.authorizer_catalog_bin_manager_cf.domain.subtype.Subtype;
+import com.credibanco.authorizer_catalog_bin_manager_cf.infrastructure.exception.AppError;
+import com.credibanco.authorizer_catalog_bin_manager_cf.infrastructure.exception.AppException;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.transaction.reactive.TransactionalOperator;
+import reactor.core.publisher.Mono;
+import reactor.test.StepVerifier;
+
+import java.time.OffsetDateTime;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+class ChangeSubtypeStatusServiceTest {
+
+    private SubtypeRepository subtypeRepository;
+    private AgencyReadOnlyRepository agencyRepository;
+    private TransactionalOperator txOperator;
+    private ChangeSubtypeStatusService service;
+
+    @BeforeEach
+    void setUp() {
+        subtypeRepository = mock(SubtypeRepository.class);
+        agencyRepository = mock(AgencyReadOnlyRepository.class);
+        txOperator = mock(TransactionalOperator.class);
+        service = new ChangeSubtypeStatusService(subtypeRepository, agencyRepository, txOperator);
+        when(txOperator.transactional(any(Mono.class))).thenAnswer(invocation -> invocation.getArgument(0));
+    }
+
+    @Test
+    void shouldFailWhenStatusInvalid() {
+        StepVerifier.create(service.execute("123456", "SUB", "X", "user"))
+                .expectErrorSatisfies(error -> {
+                    assertTrue(error instanceof AppException);
+                    assertEquals(AppError.SUBTYPE_INVALID_DATA, ((AppException) error).getError());
+                })
+                .verify();
+    }
+
+    @Test
+    void shouldFailWhenSubtypeNotFound() {
+        when(subtypeRepository.findByPk("123456", "SUB")).thenReturn(Mono.empty());
+
+        StepVerifier.create(service.execute("123456", "SUB", "A", "user"))
+                .expectErrorSatisfies(error -> {
+                    assertTrue(error instanceof AppException);
+                    assertEquals(AppError.SUBTYPE_NOT_FOUND, ((AppException) error).getError());
+                })
+                .verify();
+    }
+
+    @Test
+    void shouldValidateAgenciesWhenActivating() {
+        Subtype current = buildSubtype("SUB", "123456", "I");
+        when(subtypeRepository.findByPk("123456", "SUB")).thenReturn(Mono.just(current));
+        when(agencyRepository.countActiveBySubtypeCode("SUB")).thenReturn(Mono.just(0L));
+
+        StepVerifier.create(service.execute("123456", "SUB", "A", "user"))
+                .expectErrorSatisfies(error -> {
+                    assertTrue(error instanceof AppException);
+                    assertEquals(AppError.SUBTYPE_ACTIVATE_REQUIRES_AGENCY, ((AppException) error).getError());
+                })
+                .verify();
+    }
+
+    @Test
+    void shouldActivateWhenAgenciesPresent() {
+        Subtype current = buildSubtype("SUB", "123456", "I");
+        when(subtypeRepository.findByPk("123456", "SUB")).thenReturn(Mono.just(current));
+        when(agencyRepository.countActiveBySubtypeCode("SUB")).thenReturn(Mono.just(2L));
+        when(subtypeRepository.save(any())).thenAnswer(invocation -> Mono.just(invocation.getArgument(0)));
+
+        StepVerifier.create(service.execute("123456", "SUB", "A", "user"))
+                .assertNext(updated -> {
+                    assertEquals("A", updated.status());
+                    assertEquals("SUB", updated.subtypeCode());
+                })
+                .verifyComplete();
+
+        verify(agencyRepository).countActiveBySubtypeCode("SUB");
+    }
+
+    @Test
+    void shouldDeactivateWithoutAgencyCheck() {
+        Subtype current = buildSubtype("SUB", "123456", "A");
+        when(subtypeRepository.findByPk("123456", "SUB")).thenReturn(Mono.just(current));
+        when(subtypeRepository.save(any())).thenAnswer(invocation -> Mono.just(invocation.getArgument(0)));
+
+        StepVerifier.create(service.execute("123456", "SUB", "I", "user"))
+                .assertNext(updated -> assertEquals("I", updated.status()))
+                .verifyComplete();
+
+        verify(agencyRepository, times(0)).countActiveBySubtypeCode(any());
+    }
+
+    @Test
+    void shouldMapIllegalArgumentToAppException() {
+        Subtype current = buildSubtype("SUB", "123456", "A");
+        when(subtypeRepository.findByPk("123456", "SUB")).thenReturn(Mono.just(current));
+        when(subtypeRepository.save(any())).thenReturn(Mono.error(new IllegalArgumentException("invalid")));
+
+        StepVerifier.create(service.execute("123456", "SUB", "I", "user"))
+                .expectErrorSatisfies(error -> {
+                    assertTrue(error instanceof AppException);
+                    assertEquals(AppError.SUBTYPE_INVALID_DATA, ((AppException) error).getError());
+                })
+                .verify();
+    }
+
+    private static Subtype buildSubtype(String code, String bin, String status) {
+        OffsetDateTime now = OffsetDateTime.now();
+        return Subtype.rehydrate(code, bin, "Name", "Desc", status, null, null, null,
+                Subtype.computeBinEfectivo(bin, null), 1L, now.minusDays(1), now, "user");
+    }
+}

--- a/src/test/java/com/credibanco/authorizer_catalog_bin_manager_cf/application/subtype/use_case/CreateSubtypeServiceTest.java
+++ b/src/test/java/com/credibanco/authorizer_catalog_bin_manager_cf/application/subtype/use_case/CreateSubtypeServiceTest.java
@@ -7,15 +7,22 @@ import com.credibanco.authorizer_catalog_bin_manager_cf.infrastructure.exception
 import com.credibanco.authorizer_catalog_bin_manager_cf.infrastructure.exception.AppException;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
 import org.mockito.Mockito;
 import org.springframework.transaction.reactive.TransactionalOperator;
 import reactor.core.publisher.Mono;
 import reactor.test.StepVerifier;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
 
 class CreateSubtypeServiceTest {
@@ -52,7 +59,150 @@ class CreateSubtypeServiceTest {
                 })
                 .verify();
 
-        Mockito.verify(binRepository).getExtConfig(bin);
-        Mockito.verifyNoMoreInteractions(binRepository, subtypeRepository, idTypeRepository);
+        verify(binRepository).getExtConfig(bin);
+        verifyNoMoreInteractions(binRepository, subtypeRepository, idTypeRepository);
+    }
+
+    @Test
+    void whenOwnerIdTypeDoesNotExistShouldReturnInvalidDataError() {
+        String bin = "123456";
+        when(binRepository.getExtConfig(bin)).thenReturn(Mono.just(new BinReadOnlyRepository.BinExtConfig("Y", 2)));
+        when(idTypeRepository.existsById("CC")).thenReturn(Mono.just(false));
+
+        StepVerifier.create(service.execute("SUB", bin, "Subtype", "desc",
+                        "CC", "123", "1", "user"))
+                .expectErrorSatisfies(error -> {
+                    assertTrue(error instanceof AppException);
+                    AppException appException = (AppException) error;
+                    assertEquals(AppError.SUBTYPE_INVALID_DATA, appException.getError());
+                    assertTrue(appException.getMessage().contains("OWNER_ID_TYPE"));
+                })
+                .verify();
+
+        verify(idTypeRepository).existsById("CC");
+    }
+
+    @Test
+    void whenExtNormalizationFailsShouldReturnInvalidDataError() {
+        String bin = "123456";
+        when(binRepository.getExtConfig(bin)).thenReturn(Mono.just(new BinReadOnlyRepository.BinExtConfig("Y", 1)));
+        when(idTypeRepository.existsById("CC")).thenReturn(Mono.just(true));
+
+        StepVerifier.create(service.execute("SUB", bin, "Subtype", "desc",
+                        "CC", "123", "123", "user"))
+                .expectErrorSatisfies(error -> {
+                    assertTrue(error instanceof AppException);
+                    assertEquals(AppError.SUBTYPE_INVALID_DATA, ((AppException) error).getError());
+                })
+                .verify();
+
+        verify(idTypeRepository).existsById("CC");
+        verifyNoMoreInteractions(subtypeRepository);
+    }
+
+    @Test
+    void whenBinMasterAlreadyExistsShouldReturnCollisionError() {
+        String bin = "123456";
+        when(binRepository.getExtConfig(bin)).thenReturn(Mono.just(new BinReadOnlyRepository.BinExtConfig("Y", 2)));
+        when(idTypeRepository.existsById("CC")).thenReturn(Mono.just(true));
+        when(binRepository.existsById("12345612")).thenReturn(Mono.just(true));
+        when(subtypeRepository.existsByPk(bin, "SUB")).thenReturn(Mono.just(false));
+        when(subtypeRepository.existsByBinAndExt(bin, "12")).thenReturn(Mono.just(false));
+
+        StepVerifier.create(service.execute("SUB", bin, "Subtype", "desc",
+                        "CC", "123", "12", "user"))
+                .expectErrorSatisfies(error -> {
+                    assertTrue(error instanceof AppException);
+                    assertEquals(AppError.BIN_ALREADY_EXISTS, ((AppException) error).getError());
+                })
+                .verify();
+
+        verify(binRepository).existsById("12345612");
+    }
+
+    @Test
+    void whenSubtypeAlreadyExistsShouldReturnError() {
+        String bin = "123456";
+        when(binRepository.getExtConfig(bin)).thenReturn(Mono.just(new BinReadOnlyRepository.BinExtConfig("Y", 2)));
+        when(idTypeRepository.existsById("CC")).thenReturn(Mono.just(true));
+        when(binRepository.existsById("12345612")).thenReturn(Mono.just(false));
+        when(subtypeRepository.existsByPk(bin, "SUB")).thenReturn(Mono.just(true));
+        when(subtypeRepository.existsByBinAndExt(bin, "12")).thenReturn(Mono.just(false));
+
+        StepVerifier.create(service.execute("SUB", bin, "Subtype", "desc",
+                        "CC", "123", "12", "user"))
+                .expectErrorSatisfies(error -> {
+                    assertTrue(error instanceof AppException);
+                    assertEquals(AppError.SUBTYPE_ALREADY_EXISTS, ((AppException) error).getError());
+                })
+                .verify();
+
+        verify(subtypeRepository).existsByPk(bin, "SUB");
+    }
+
+    @Test
+    void whenBinExtAlreadyUsedShouldReturnError() {
+        String bin = "123456";
+        when(binRepository.getExtConfig(bin)).thenReturn(Mono.just(new BinReadOnlyRepository.BinExtConfig("Y", 2)));
+        when(idTypeRepository.existsById("CC")).thenReturn(Mono.just(true));
+        when(binRepository.existsById("12345612")).thenReturn(Mono.just(false));
+        when(subtypeRepository.existsByPk(bin, "SUB")).thenReturn(Mono.just(false));
+        when(subtypeRepository.existsByBinAndExt(bin, "12")).thenReturn(Mono.just(true));
+
+        StepVerifier.create(service.execute("SUB", bin, "Subtype", "desc",
+                        "CC", "123", "12", "user"))
+                .expectErrorSatisfies(error -> {
+                    assertTrue(error instanceof AppException);
+                    assertEquals(AppError.SUBTYPE_ALREADY_EXISTS, ((AppException) error).getError());
+                })
+                .verify();
+
+        verify(subtypeRepository).existsByBinAndExt(bin, "12");
+    }
+
+    @Test
+    void whenBinDoesNotUseExtensionsShouldIgnoreBinExtValue() {
+        String bin = "654321";
+        when(binRepository.getExtConfig(bin)).thenReturn(Mono.just(new BinReadOnlyRepository.BinExtConfig("N", null)));
+        when(idTypeRepository.existsById(null)).thenReturn(Mono.just(true));
+        when(binRepository.existsById(bin)).thenReturn(Mono.just(false));
+        when(subtypeRepository.existsByPk(bin, "SUB")).thenReturn(Mono.just(false));
+        when(subtypeRepository.existsByBinAndExt(eq(bin), any())).thenReturn(Mono.just(false));
+        when(subtypeRepository.save(any())).thenAnswer(invocation -> Mono.just(invocation.getArgument(0)));
+
+        StepVerifier.create(service.execute("SUB", bin, "Subtype", "desc",
+                        null, null, "99", "user"))
+                .assertNext(subtype -> {
+                    assertEquals("SUB", subtype.subtypeCode());
+                    assertEquals(bin, subtype.bin());
+                    assertNull(subtype.binExt());
+                })
+                .verifyComplete();
+
+        verify(subtypeRepository, times(0)).existsByBinAndExt(any(), any());
+    }
+
+    @Test
+    void whenCreationSucceedsShouldPersistSubtype() {
+        String bin = "123456";
+        when(binRepository.getExtConfig(bin)).thenReturn(Mono.just(new BinReadOnlyRepository.BinExtConfig("Y", 2)));
+        when(idTypeRepository.existsById("CC")).thenReturn(Mono.just(true));
+        when(binRepository.existsById("12345612")).thenReturn(Mono.just(false));
+        when(subtypeRepository.existsByPk(bin, "SUB")).thenReturn(Mono.just(false));
+        when(subtypeRepository.existsByBinAndExt(bin, "12")).thenReturn(Mono.just(false));
+        when(subtypeRepository.save(any())).thenAnswer(invocation -> Mono.just(invocation.getArgument(0)));
+
+        StepVerifier.create(service.execute("SUB", bin, "Subtype", "desc",
+                        "CC", "123", "12", "user"))
+                .assertNext(subtype -> {
+                    assertEquals("SUB", subtype.subtypeCode());
+                    assertEquals("12345612", subtype.binEfectivo());
+                    assertNotNull(subtype.updatedAt());
+                })
+                .verifyComplete();
+
+        ArgumentCaptor<String> extCaptor = ArgumentCaptor.forClass(String.class);
+        verify(subtypeRepository).existsByBinAndExt(eq(bin), extCaptor.capture());
+        assertEquals("12", extCaptor.getValue());
     }
 }

--- a/src/test/java/com/credibanco/authorizer_catalog_bin_manager_cf/application/subtype/use_case/GetSubtypeServiceTest.java
+++ b/src/test/java/com/credibanco/authorizer_catalog_bin_manager_cf/application/subtype/use_case/GetSubtypeServiceTest.java
@@ -1,0 +1,52 @@
+package com.credibanco.authorizer_catalog_bin_manager_cf.application.subtype.use_case;
+
+import com.credibanco.authorizer_catalog_bin_manager_cf.application.subtype.port.outbound.SubtypeRepository;
+import com.credibanco.authorizer_catalog_bin_manager_cf.domain.subtype.Subtype;
+import com.credibanco.authorizer_catalog_bin_manager_cf.infrastructure.exception.AppError;
+import com.credibanco.authorizer_catalog_bin_manager_cf.infrastructure.exception.AppException;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import reactor.core.publisher.Mono;
+import reactor.test.StepVerifier;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+class GetSubtypeServiceTest {
+
+    private SubtypeRepository subtypeRepository;
+    private GetSubtypeService service;
+
+    @BeforeEach
+    void setUp() {
+        subtypeRepository = mock(SubtypeRepository.class);
+        service = new GetSubtypeService(subtypeRepository);
+    }
+
+    @Test
+    void shouldReturnSubtypeWhenFound() {
+        Subtype subtype = Subtype.createNew("SUB", "123456", "Name", "Desc", null, null, null, "user");
+        when(subtypeRepository.findByPk("123456", "SUB")).thenReturn(Mono.just(subtype));
+
+        StepVerifier.create(service.execute("123456", "SUB"))
+                .expectNext(subtype)
+                .verifyComplete();
+
+        verify(subtypeRepository).findByPk("123456", "SUB");
+    }
+
+    @Test
+    void shouldReturnNotFoundErrorWhenMissing() {
+        when(subtypeRepository.findByPk("123456", "SUB")).thenReturn(Mono.empty());
+
+        StepVerifier.create(service.execute("123456", "SUB"))
+                .expectErrorSatisfies(error -> {
+                    assertTrue(error instanceof AppException);
+                    assertEquals(AppError.SUBTYPE_NOT_FOUND, ((AppException) error).getError());
+                })
+                .verify();
+    }
+}

--- a/src/test/java/com/credibanco/authorizer_catalog_bin_manager_cf/application/subtype/use_case/ListSubtypesServiceTest.java
+++ b/src/test/java/com/credibanco/authorizer_catalog_bin_manager_cf/application/subtype/use_case/ListSubtypesServiceTest.java
@@ -1,0 +1,91 @@
+package com.credibanco.authorizer_catalog_bin_manager_cf.application.subtype.use_case;
+
+import com.credibanco.authorizer_catalog_bin_manager_cf.application.subtype.port.outbound.BinReadOnlyRepository;
+import com.credibanco.authorizer_catalog_bin_manager_cf.application.subtype.port.outbound.SubtypeRepository;
+import com.credibanco.authorizer_catalog_bin_manager_cf.domain.subtype.Subtype;
+import com.credibanco.authorizer_catalog_bin_manager_cf.infrastructure.exception.AppError;
+import com.credibanco.authorizer_catalog_bin_manager_cf.infrastructure.exception.AppException;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+import reactor.test.StepVerifier;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+class ListSubtypesServiceTest {
+
+    private SubtypeRepository subtypeRepository;
+    private BinReadOnlyRepository binRepository;
+    private ListSubtypesService service;
+
+    @BeforeEach
+    void setUp() {
+        subtypeRepository = mock(SubtypeRepository.class);
+        binRepository = mock(BinReadOnlyRepository.class);
+        service = new ListSubtypesService(subtypeRepository, binRepository);
+    }
+
+    @Test
+    void shouldFailWhenPageOrSizeInvalid() {
+        StepVerifier.create(service.execute("123456", null, null, -1, 10))
+                .expectErrorSatisfies(error -> {
+                    assertTrue(error instanceof AppException);
+                    assertEquals(AppError.SUBTYPE_INVALID_DATA, ((AppException) error).getError());
+                })
+                .verify();
+
+        StepVerifier.create(service.execute("123456", null, null, 0, 0))
+                .expectError(AppException.class)
+                .verify();
+
+        verifyNoInteractions(subtypeRepository, binRepository);
+    }
+
+    @Test
+    void shouldValidateBinExistenceWhenFilterPresent() {
+        when(binRepository.existsById("123456")).thenReturn(Mono.just(true));
+        Subtype subtype = Subtype.createNew("SUB", "123456", "Name", "Desc", null, null, null, "user");
+        when(subtypeRepository.findAll("123456", "S", "A", 0, 5)).thenReturn(Flux.fromIterable(List.of(subtype)));
+
+        StepVerifier.create(service.execute("123456", "S", "A", 0, 5))
+                .expectNext(subtype)
+                .verifyComplete();
+
+        verify(binRepository).existsById("123456");
+    }
+
+    @Test
+    void shouldReturnErrorWhenBinFilterNotFound() {
+        when(binRepository.existsById("123456")).thenReturn(Mono.just(false));
+
+        StepVerifier.create(service.execute("123456", null, null, 0, 10))
+                .expectErrorSatisfies(error -> {
+                    assertTrue(error instanceof AppException);
+                    assertEquals(AppError.BIN_NOT_FOUND, ((AppException) error).getError());
+                })
+                .verify();
+    }
+
+    @Test
+    void shouldListWithoutBinFilter() {
+        Subtype subtype1 = Subtype.createNew("S1", "123456", "Name1", "Desc1", null, null, null, "user");
+        Subtype subtype2 = Subtype.createNew("S2", "123456", "Name2", "Desc2", null, null, null, "user");
+        when(subtypeRepository.findAll(null, null, null, 1, 2)).thenReturn(Flux.fromIterable(List.of(subtype1, subtype2)));
+
+        StepVerifier.create(service.execute(null, null, null, 1, 2))
+                .expectNext(subtype1)
+                .expectNext(subtype2)
+                .verifyComplete();
+
+        verify(subtypeRepository).findAll(null, null, null, 1, 2);
+        verifyNoInteractions(binRepository);
+    }
+}

--- a/src/test/java/com/credibanco/authorizer_catalog_bin_manager_cf/application/subtype/use_case/UpdateSubtypeBasicsServiceTest.java
+++ b/src/test/java/com/credibanco/authorizer_catalog_bin_manager_cf/application/subtype/use_case/UpdateSubtypeBasicsServiceTest.java
@@ -1,0 +1,155 @@
+package com.credibanco.authorizer_catalog_bin_manager_cf.application.subtype.use_case;
+
+import com.credibanco.authorizer_catalog_bin_manager_cf.application.subtype.port.outbound.BinReadOnlyRepository;
+import com.credibanco.authorizer_catalog_bin_manager_cf.application.subtype.port.outbound.SubtypeRepository;
+import com.credibanco.authorizer_catalog_bin_manager_cf.domain.subtype.Subtype;
+import com.credibanco.authorizer_catalog_bin_manager_cf.infrastructure.exception.AppError;
+import com.credibanco.authorizer_catalog_bin_manager_cf.infrastructure.exception.AppException;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.transaction.reactive.TransactionalOperator;
+import reactor.core.publisher.Mono;
+import reactor.test.StepVerifier;
+
+import java.time.OffsetDateTime;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+import static org.mockito.Mockito.when;
+
+class UpdateSubtypeBasicsServiceTest {
+
+    private SubtypeRepository subtypeRepository;
+    private BinReadOnlyRepository binRepository;
+    private TransactionalOperator txOperator;
+    private UpdateSubtypeBasicsService service;
+
+    @BeforeEach
+    void setUp() {
+        subtypeRepository = mock(SubtypeRepository.class);
+        binRepository = mock(BinReadOnlyRepository.class);
+        txOperator = mock(TransactionalOperator.class);
+        service = new UpdateSubtypeBasicsService(subtypeRepository, binRepository, txOperator);
+        when(txOperator.transactional(any(Mono.class))).thenAnswer(invocation -> invocation.getArgument(0));
+    }
+
+    @Test
+    void shouldReturnNotFoundWhenSubtypeMissing() {
+        when(subtypeRepository.findByPk("123456", "SUB")).thenReturn(Mono.empty());
+
+        StepVerifier.create(service.execute("123456", "SUB", "Name", "Desc", null, null, null, "user"))
+                .expectErrorSatisfies(error -> {
+                    assertTrue(error instanceof AppException);
+                    assertEquals(AppError.SUBTYPE_NOT_FOUND, ((AppException) error).getError());
+                })
+                .verify();
+    }
+
+    @Test
+    void shouldReturnErrorWhenBinConfigMissing() {
+        Subtype current = buildSubtype("SUB", "123456", "01", "I");
+        when(subtypeRepository.findByPk("123456", "SUB")).thenReturn(Mono.just(current));
+        when(binRepository.getExtConfig("123456")).thenReturn(Mono.empty());
+
+        StepVerifier.create(service.execute("123456", "SUB", "Name", "Desc", null, null, null, "user"))
+                .expectErrorSatisfies(error -> {
+                    assertTrue(error instanceof AppException);
+                    assertEquals(AppError.BIN_NOT_FOUND, ((AppException) error).getError());
+                })
+                .verify();
+    }
+
+    @Test
+    void shouldReturnErrorWhenExtNormalizationFails() {
+        Subtype current = buildSubtype("SUB", "123456", "01", "I");
+        when(subtypeRepository.findByPk("123456", "SUB")).thenReturn(Mono.just(current));
+        when(binRepository.getExtConfig("123456")).thenReturn(Mono.just(new BinReadOnlyRepository.BinExtConfig("Y", 1)));
+
+        StepVerifier.create(service.execute("123456", "SUB", "Name", "Desc", null, null, "999", "user"))
+                .expectErrorSatisfies(error -> {
+                    assertTrue(error instanceof AppException);
+                    assertEquals(AppError.SUBTYPE_INVALID_DATA, ((AppException) error).getError());
+                })
+                .verify();
+    }
+
+    @Test
+    void shouldCheckBinExtUniquenessWhenChanged() {
+        Subtype current = buildSubtype("SUB", "123456", "01", "I");
+        when(subtypeRepository.findByPk("123456", "SUB")).thenReturn(Mono.just(current));
+        when(binRepository.getExtConfig("123456")).thenReturn(Mono.just(new BinReadOnlyRepository.BinExtConfig("Y", 2)));
+        when(subtypeRepository.existsByBinAndExt("123456", "02")).thenReturn(Mono.just(true));
+
+        StepVerifier.create(service.execute("123456", "SUB", "Name", "Desc", null, null, "02", "user"))
+                .expectErrorSatisfies(error -> {
+                    assertTrue(error instanceof AppException);
+                    assertEquals(AppError.SUBTYPE_ALREADY_EXISTS, ((AppException) error).getError());
+                })
+                .verify();
+    }
+
+    @Test
+    void shouldSkipUniquenessCheckWhenExtDoesNotChange() {
+        Subtype current = buildSubtype("SUB", "123456", "01", "I");
+        when(subtypeRepository.findByPk("123456", "SUB")).thenReturn(Mono.just(current));
+        when(binRepository.getExtConfig("123456")).thenReturn(Mono.just(new BinReadOnlyRepository.BinExtConfig("Y", 2)));
+        when(subtypeRepository.save(any())).thenAnswer(invocation -> Mono.just(invocation.getArgument(0)));
+
+        StepVerifier.create(service.execute("123456", "SUB", "New", "Desc", null, null, "01", "user"))
+                .assertNext(updated -> {
+                    assertEquals("New", updated.name());
+                    assertEquals("01", updated.binExt());
+                })
+                .verifyComplete();
+
+        verify(subtypeRepository, times(0)).existsByBinAndExt(any(), any());
+    }
+
+    @Test
+    void shouldUpdateSubtypeWhenExtChanges() {
+        Subtype current = buildSubtype("SUB", "123456", null, "I");
+        when(subtypeRepository.findByPk("123456", "SUB")).thenReturn(Mono.just(current));
+        when(binRepository.getExtConfig("123456")).thenReturn(Mono.just(new BinReadOnlyRepository.BinExtConfig("Y", 2)));
+        when(subtypeRepository.existsByBinAndExt("123456", "01")).thenReturn(Mono.just(false));
+        when(subtypeRepository.save(any())).thenAnswer(invocation -> Mono.just(invocation.getArgument(0)));
+
+        StepVerifier.create(service.execute("123456", "SUB", "New", "Desc", null, null, "01", "user"))
+                .assertNext(updated -> {
+                    assertEquals("01", updated.binExt());
+                    assertEquals("12345601", updated.binEfectivo());
+                    assertNotEquals(current.updatedAt(), updated.updatedAt());
+                })
+                .verifyComplete();
+    }
+
+    @Test
+    void shouldHandleBinsWithoutExtensionUsage() {
+        Subtype current = buildSubtype("SUB", "123456", null, "I");
+        when(subtypeRepository.findByPk("123456", "SUB")).thenReturn(Mono.just(current));
+        when(binRepository.getExtConfig("123456")).thenReturn(Mono.just(new BinReadOnlyRepository.BinExtConfig("N", null)));
+        when(subtypeRepository.save(any())).thenAnswer(invocation -> Mono.just(invocation.getArgument(0)));
+
+        StepVerifier.create(service.execute("123456", "SUB", "New", "Desc", null, null, "99", "user"))
+                .assertNext(updated -> {
+                    assertEquals("New", updated.name());
+                    assertEquals(current.binExt(), updated.binExt());
+                })
+                .verifyComplete();
+
+        verify(subtypeRepository, times(0)).existsByBinAndExt(any(), any());
+        verify(binRepository).getExtConfig("123456");
+        verifyNoMoreInteractions(binRepository);
+    }
+
+    private static Subtype buildSubtype(String code, String bin, String binExt, String status) {
+        OffsetDateTime now = OffsetDateTime.now();
+        return Subtype.rehydrate(code, bin, "Name", "Desc", status, null, null, binExt,
+                Subtype.computeBinEfectivo(bin, binExt), 1L, now.minusDays(1), now, "user");
+    }
+}

--- a/src/test/java/com/credibanco/authorizer_catalog_bin_manager_cf/domain/subtype/SubtypeTest.java
+++ b/src/test/java/com/credibanco/authorizer_catalog_bin_manager_cf/domain/subtype/SubtypeTest.java
@@ -1,0 +1,70 @@
+package com.credibanco.authorizer_catalog_bin_manager_cf.domain.subtype;
+
+import org.junit.jupiter.api.Test;
+
+import java.time.OffsetDateTime;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class SubtypeTest {
+
+    @Test
+    void createNewShouldNormalizeValues() {
+        Subtype subtype = Subtype.createNew("ABC", "123-456", "Name", "Desc", "CC", "123", "7", "user");
+        assertEquals("123456", subtype.bin());
+        assertEquals("7", subtype.binExt());
+        assertEquals("1234567", subtype.binEfectivo());
+        assertEquals("I", subtype.status());
+    }
+
+    @Test
+    void updateBasicsShouldRefreshFields() {
+        Subtype original = Subtype.createNew("ABC", "123456", "Name", "Desc", null, null, "7", "user");
+        Subtype updated = original.updateBasics("New", "Desc2", "TI", "456", "9", "admin");
+        assertEquals("New", updated.name());
+        assertEquals("Desc2", updated.description());
+        assertEquals("9", updated.binExt());
+        assertEquals("1234569", updated.binEfectivo());
+        assertNotNull(updated.updatedAt());
+    }
+
+    @Test
+    void changeStatusShouldValidateInput() {
+        Subtype original = Subtype.createNew("ABC", "123456", "Name", "Desc", null, null, null, "user");
+        Subtype active = original.changeStatus("A", "admin");
+        assertEquals("A", active.status());
+        assertThrows(IllegalArgumentException.class, () -> original.changeStatus("X", "admin"));
+    }
+
+    @Test
+    void rehydrateShouldValidateConsistency() {
+        OffsetDateTime now = OffsetDateTime.now();
+        assertThrows(IllegalArgumentException.class, () ->
+                Subtype.rehydrate("ABC", "123456", "Name", "Desc", "A",
+                        null, null, "1", "999999", 1L, now, now, null));
+    }
+
+    @Test
+    void shouldValidateBinLengthAndRequiredFields() {
+        IllegalArgumentException ex = assertThrows(IllegalArgumentException.class, () ->
+                Subtype.createNew("AB", "123456", "", "Desc", null, null, null, "user"));
+        assertTrue(ex.getMessage().contains("name"));
+
+        assertThrows(IllegalArgumentException.class, () ->
+                Subtype.createNew("ABC", "12345", "Name", "Desc", null, null, null, "user"));
+        assertThrows(IllegalArgumentException.class, () ->
+                Subtype.createNew("ABC", "1234567890", "Name", "Desc", null, null, null, "user"));
+    }
+
+    @Test
+    void digitsOnlyOrNullShouldRemoveNonDigits() {
+        Subtype subtype = Subtype.createNew("ABC", "123456", "Name", "Desc", null, null, "  a", "user");
+        assertEquals("123456", subtype.bin());
+        assertNull(subtype.binExt());
+        assertEquals("", Subtype.computeBinEfectivo("", null));
+    }
+}


### PR DESCRIPTION
## Summary
- add mocked unit tests that cover the subtype domain record and all subtype application services
- extend the existing create subtype tests to exercise happy paths and error handling scenarios

## Testing
- `mvn -q test` *(fails: dependency download blocked in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e27b458a64832e82f84b6afb584740