### PR TITLE
Add unit tests for agency application services

### DIFF
--- a/src/test/java/com/credibanco/authorizer_catalog_bin_manager_cf/application/agency/use_case/ChangeAgencyStatusServiceTest.java
+++ b/src/test/java/com/credibanco/authorizer_catalog_bin_manager_cf/application/agency/use_case/ChangeAgencyStatusServiceTest.java
@@ -1,0 +1,152 @@
+package com.credibanco.authorizer_catalog_bin_manager_cf.application.agency.use_case;
+
+import com.credibanco.authorizer_catalog_bin_manager_cf.application.agency.port.outbound.AgencyRepository;
+import com.credibanco.authorizer_catalog_bin_manager_cf.application.agency.port.outbound.SubtypeReadOnlyRepository;
+import com.credibanco.authorizer_catalog_bin_manager_cf.domain.agency.Agency;
+import com.credibanco.authorizer_catalog_bin_manager_cf.infrastructure.exception.AppError;
+import com.credibanco.authorizer_catalog_bin_manager_cf.infrastructure.exception.AppException;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.reactivestreams.Publisher;
+import org.springframework.transaction.reactive.TransactionalOperator;
+import reactor.core.publisher.Mono;
+import reactor.test.StepVerifier;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.*;
+
+class ChangeAgencyStatusServiceTest {
+
+    private AgencyRepository repo;
+    private SubtypeReadOnlyRepository subtypeRepo;
+    private TransactionalOperator txOperator;
+    private ChangeAgencyStatusService service;
+
+    @BeforeEach
+    void setUp() {
+        repo = mock(AgencyRepository.class);
+        subtypeRepo = mock(SubtypeReadOnlyRepository.class);
+        txOperator = mock(TransactionalOperator.class);
+        service = new ChangeAgencyStatusService(repo, subtypeRepo, txOperator);
+
+        when(txOperator.transactional(any(Publisher.class)))
+                .thenAnswer(invocation -> invocation.getArgument(0));
+    }
+
+    @Test
+    void whenStatusInvalidThenEmitInvalidData() {
+        StepVerifier.create(service.execute("01", "001", "X", "tester"))
+                .expectErrorSatisfies(error -> {
+                    assertTrue(error instanceof AppException);
+                    AppException appException = (AppException) error;
+                    assertEquals(AppError.AGENCY_INVALID_DATA, appException.getError());
+                    assertTrue(appException.getMessage().contains("status"));
+                })
+                .verify();
+
+        verifyNoInteractions(repo, subtypeRepo);
+    }
+
+    @Test
+    void whenAgencyMissingThenEmitNotFound() {
+        when(repo.findByPk("01", "001")).thenReturn(Mono.empty());
+
+        StepVerifier.create(service.execute("01", "001", "A", "tester"))
+                .expectErrorSatisfies(error -> {
+                    assertTrue(error instanceof AppException);
+                    assertEquals(AppError.AGENCY_NOT_FOUND, ((AppException) error).getError());
+                })
+                .verify();
+
+        verify(repo).findByPk("01", "001");
+        verifyNoMoreInteractions(repo);
+        verifyNoInteractions(subtypeRepo);
+    }
+
+    @Test
+    void whenSubtypeMissingThenEmitSubtypeNotFound() {
+        Agency current = Agency.rehydrate("01", "001", "Agency", null, null, null, null,
+                null, null, null, null, null, null, null, null, null, "A", null, null, null);
+        when(repo.findByPk("01", "001")).thenReturn(Mono.just(current));
+        when(subtypeRepo.existsByCode("01")).thenReturn(Mono.just(false));
+
+        StepVerifier.create(service.execute("01", "001", "A", "tester"))
+                .expectErrorSatisfies(error -> {
+                    assertTrue(error instanceof AppException);
+                    assertEquals(AppError.SUBTYPE_NOT_FOUND, ((AppException) error).getError());
+                })
+                .verify();
+
+        verify(repo).findByPk("01", "001");
+        verify(subtypeRepo).existsByCode("01");
+        verifyNoMoreInteractions(repo);
+    }
+
+    @Test
+    void whenInactivatingOnlyActiveAgencyThenEmitConflict() {
+        Agency current = Agency.rehydrate("01", "001", "Agency", null, null, null, null,
+                null, null, null, null, null, null, null, null, null, "A", null, null, null);
+        when(repo.findByPk("01", "001")).thenReturn(Mono.just(current));
+        when(subtypeRepo.existsByCode("01")).thenReturn(Mono.just(true));
+        when(repo.existsAnotherActive("01", "001")).thenReturn(Mono.just(false));
+
+        StepVerifier.create(service.execute("01", "001", "I", "tester"))
+                .expectErrorSatisfies(error -> {
+                    assertTrue(error instanceof AppException);
+                    AppException appException = (AppException) error;
+                    assertEquals(AppError.AGENCY_CONFLICT_RULE, appException.getError());
+                    assertTrue(appException.getMessage().contains("única"));
+                })
+                .verify();
+
+        verify(repo).findByPk("01", "001");
+        verify(subtypeRepo).existsByCode("01");
+        verify(repo).existsAnotherActive("01", "001");
+        verifyNoMoreInteractions(repo);
+    }
+
+    @Test
+    void whenSaveFailsWithIllegalArgumentThenWrapInAppException() {
+        Agency current = Agency.rehydrate("01", "001", "Agency", null, null, null, null,
+                null, null, null, null, null, null, null, null, null, "I", null, null, null);
+        when(repo.findByPk("01", "001")).thenReturn(Mono.just(current));
+        when(subtypeRepo.existsByCode("01")).thenReturn(Mono.just(true));
+        when(repo.save(any(Agency.class))).thenReturn(Mono.error(new IllegalArgumentException("invalid status")));
+
+        StepVerifier.create(service.execute("01", "001", "A", "tester"))
+                .expectErrorSatisfies(error -> {
+                    assertTrue(error instanceof AppException);
+                    AppException appException = (AppException) error;
+                    assertEquals(AppError.AGENCY_INVALID_DATA, appException.getError());
+                    assertEquals("invalid status", appException.getMessage());
+                })
+                .verify();
+
+        verify(repo).findByPk("01", "001");
+        verify(subtypeRepo).existsByCode("01");
+        verify(repo).save(any(Agency.class));
+    }
+
+    @Test
+    void whenChangeStatusSucceedsThenPersistAndReturn() {
+        Agency current = Agency.rehydrate("01", "001", "Agency", null, null, null, null,
+                null, null, null, null, null, null, null, null, null, "A", null, null, null);
+        when(repo.findByPk("01", "001")).thenReturn(Mono.just(current));
+        when(subtypeRepo.existsByCode("01")).thenReturn(Mono.just(true));
+        when(repo.existsAnotherActive("01", "001")).thenReturn(Mono.just(true));
+        when(repo.save(any(Agency.class))).thenAnswer(invocation -> Mono.just(invocation.getArgument(0)));
+
+        StepVerifier.create(service.execute("01", "001", "I", "tester"))
+                .assertNext(saved -> {
+                    assertEquals("I", saved.status());
+                    assertEquals("tester", saved.updatedBy());
+                })
+                .verifyComplete();
+
+        verify(repo).findByPk("01", "001");
+        verify(subtypeRepo).existsByCode("01");
+        verify(repo).existsAnotherActive("01", "001");
+        verify(repo).save(any(Agency.class));
+    }
+}

--- a/src/test/java/com/credibanco/authorizer_catalog_bin_manager_cf/application/agency/use_case/CreateAgencyServiceTest.java
+++ b/src/test/java/com/credibanco/authorizer_catalog_bin_manager_cf/application/agency/use_case/CreateAgencyServiceTest.java
@@ -1,0 +1,115 @@
+package com.credibanco.authorizer_catalog_bin_manager_cf.application.agency.use_case;
+
+import com.credibanco.authorizer_catalog_bin_manager_cf.application.agency.port.outbound.AgencyRepository;
+import com.credibanco.authorizer_catalog_bin_manager_cf.application.agency.port.outbound.SubtypeReadOnlyRepository;
+import com.credibanco.authorizer_catalog_bin_manager_cf.domain.agency.Agency;
+import com.credibanco.authorizer_catalog_bin_manager_cf.infrastructure.exception.AppError;
+import com.credibanco.authorizer_catalog_bin_manager_cf.infrastructure.exception.AppException;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.reactivestreams.Publisher;
+import org.springframework.transaction.reactive.TransactionalOperator;
+import reactor.core.publisher.Mono;
+import reactor.test.StepVerifier;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+class CreateAgencyServiceTest {
+
+    private AgencyRepository repo;
+    private SubtypeReadOnlyRepository subtypeRepo;
+    private TransactionalOperator txOperator;
+    private CreateAgencyService service;
+
+    @BeforeEach
+    void setUp() {
+        repo = mock(AgencyRepository.class);
+        subtypeRepo = mock(SubtypeReadOnlyRepository.class);
+        txOperator = mock(TransactionalOperator.class);
+        service = new CreateAgencyService(repo, subtypeRepo, txOperator);
+
+        when(txOperator.transactional(any(Publisher.class)))
+                .thenAnswer(invocation -> invocation.getArgument(0));
+    }
+
+    @Test
+    void whenSubtypeDoesNotExistThenEmitSubtypeNotFound() {
+        Agency draft = Agency.createNew("01", "001", "Agency", null, null, null, null,
+                null, null, null, null, null, null, null, null, null, null, "tester");
+        when(subtypeRepo.existsByCode("01")).thenReturn(Mono.just(false));
+
+        StepVerifier.create(service.execute(draft))
+                .expectErrorSatisfies(error -> {
+                    assertTrue(error instanceof AppException);
+                    AppException appException = (AppException) error;
+                    assertEquals(AppError.SUBTYPE_NOT_FOUND, appException.getError());
+                    assertTrue(appException.getMessage().contains("subtypeCode=01"));
+                })
+                .verify();
+
+        verify(subtypeRepo).existsByCode("01");
+        verifyNoInteractions(repo);
+    }
+
+    @Test
+    void whenAgencyAlreadyExistsThenEmitConflictError() {
+        Agency draft = Agency.createNew("01", "001", "Agency", null, null, null, null,
+                null, null, null, null, null, null, null, null, null, null, "tester");
+        when(subtypeRepo.existsByCode("01")).thenReturn(Mono.just(true));
+        when(repo.existsByPk("01", "001")).thenReturn(Mono.just(true));
+
+        StepVerifier.create(service.execute(draft))
+                .expectErrorSatisfies(error -> {
+                    assertTrue(error instanceof AppException);
+                    assertEquals(AppError.AGENCY_ALREADY_EXISTS, ((AppException) error).getError());
+                })
+                .verify();
+
+        verify(subtypeRepo).existsByCode("01");
+        verify(repo).existsByPk("01", "001");
+        verifyNoMoreInteractions(repo);
+    }
+
+    @Test
+    void whenSaveFailsWithIllegalArgumentThenWrapInAppException() {
+        Agency draft = Agency.createNew("01", "001", "Agency", null, null, null, null,
+                null, null, null, null, null, null, null, null, null, null, "tester");
+        when(subtypeRepo.existsByCode("01")).thenReturn(Mono.just(true));
+        when(repo.existsByPk("01", "001")).thenReturn(Mono.just(false));
+        when(repo.save(draft)).thenReturn(Mono.error(new IllegalArgumentException("invalid")));
+
+        StepVerifier.create(service.execute(draft))
+                .expectErrorSatisfies(error -> {
+                    assertTrue(error instanceof AppException);
+                    AppException appException = (AppException) error;
+                    assertEquals(AppError.AGENCY_INVALID_DATA, appException.getError());
+                    assertEquals("invalid", appException.getMessage());
+                })
+                .verify();
+
+        verify(subtypeRepo).existsByCode("01");
+        verify(repo).existsByPk("01", "001");
+        verify(repo).save(draft);
+        verifyNoMoreInteractions(repo);
+    }
+
+    @Test
+    void whenDraftValidThenSaveAndReturnAgency() {
+        Agency draft = Agency.createNew("01", "001", "Agency", null, null, null, null,
+                null, null, null, null, null, null, null, null, null, null, "tester");
+        when(subtypeRepo.existsByCode("01")).thenReturn(Mono.just(true));
+        when(repo.existsByPk("01", "001")).thenReturn(Mono.just(false));
+        when(repo.save(draft)).thenReturn(Mono.just(draft));
+
+        StepVerifier.create(service.execute(draft))
+                .expectNext(draft)
+                .verifyComplete();
+
+        verify(subtypeRepo).existsByCode("01");
+        verify(repo).existsByPk("01", "001");
+        verify(repo).save(draft);
+        verifyNoMoreInteractions(repo);
+    }
+}

--- a/src/test/java/com/credibanco/authorizer_catalog_bin_manager_cf/application/agency/use_case/GetAgencyServiceTest.java
+++ b/src/test/java/com/credibanco/authorizer_catalog_bin_manager_cf/application/agency/use_case/GetAgencyServiceTest.java
@@ -1,0 +1,76 @@
+package com.credibanco.authorizer_catalog_bin_manager_cf.application.agency.use_case;
+
+import com.credibanco.authorizer_catalog_bin_manager_cf.application.agency.port.outbound.AgencyRepository;
+import com.credibanco.authorizer_catalog_bin_manager_cf.application.agency.port.outbound.SubtypeReadOnlyRepository;
+import com.credibanco.authorizer_catalog_bin_manager_cf.domain.agency.Agency;
+import com.credibanco.authorizer_catalog_bin_manager_cf.infrastructure.exception.AppError;
+import com.credibanco.authorizer_catalog_bin_manager_cf.infrastructure.exception.AppException;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import reactor.core.publisher.Mono;
+import reactor.test.StepVerifier;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+class GetAgencyServiceTest {
+
+    private AgencyRepository repo;
+    private SubtypeReadOnlyRepository subtypeRepo;
+    private GetAgencyService service;
+
+    @BeforeEach
+    void setUp() {
+        repo = mock(AgencyRepository.class);
+        subtypeRepo = mock(SubtypeReadOnlyRepository.class);
+        service = new GetAgencyService(repo, subtypeRepo);
+    }
+
+    @Test
+    void whenSubtypeMissingThenEmitSubtypeNotFound() {
+        when(subtypeRepo.existsByCode("01")).thenReturn(Mono.just(false));
+
+        StepVerifier.create(service.execute("01", "001"))
+                .expectErrorSatisfies(error -> {
+                    assertTrue(error instanceof AppException);
+                    assertEquals(AppError.SUBTYPE_NOT_FOUND, ((AppException) error).getError());
+                })
+                .verify();
+
+        verify(subtypeRepo).existsByCode("01");
+        verifyNoInteractions(repo);
+    }
+
+    @Test
+    void whenAgencyMissingThenEmitNotFound() {
+        when(subtypeRepo.existsByCode("01")).thenReturn(Mono.just(true));
+        when(repo.findByPk("01", "001")).thenReturn(Mono.empty());
+
+        StepVerifier.create(service.execute("01", "001"))
+                .expectErrorSatisfies(error -> {
+                    assertTrue(error instanceof AppException);
+                    assertEquals(AppError.AGENCY_NOT_FOUND, ((AppException) error).getError());
+                })
+                .verify();
+
+        verify(subtypeRepo).existsByCode("01");
+        verify(repo).findByPk("01", "001");
+        verifyNoMoreInteractions(repo);
+    }
+
+    @Test
+    void whenAgencyExistsThenReturnIt() {
+        Agency agency = Agency.rehydrate("01", "001", "Agency", null, null, null, null,
+                null, null, null, null, null, null, null, null, null, "A", null, null, null);
+        when(subtypeRepo.existsByCode("01")).thenReturn(Mono.just(true));
+        when(repo.findByPk("01", "001")).thenReturn(Mono.just(agency));
+
+        StepVerifier.create(service.execute("01", "001"))
+                .expectNext(agency)
+                .verifyComplete();
+
+        verify(subtypeRepo).existsByCode("01");
+        verify(repo).findByPk("01", "001");
+        verifyNoMoreInteractions(repo);
+    }
+}

--- a/src/test/java/com/credibanco/authorizer_catalog_bin_manager_cf/application/agency/use_case/ListAgenciesServiceTest.java
+++ b/src/test/java/com/credibanco/authorizer_catalog_bin_manager_cf/application/agency/use_case/ListAgenciesServiceTest.java
@@ -1,0 +1,90 @@
+package com.credibanco.authorizer_catalog_bin_manager_cf.application.agency.use_case;
+
+import com.credibanco.authorizer_catalog_bin_manager_cf.application.agency.port.outbound.AgencyRepository;
+import com.credibanco.authorizer_catalog_bin_manager_cf.application.agency.port.outbound.SubtypeReadOnlyRepository;
+import com.credibanco.authorizer_catalog_bin_manager_cf.domain.agency.Agency;
+import com.credibanco.authorizer_catalog_bin_manager_cf.infrastructure.exception.AppError;
+import com.credibanco.authorizer_catalog_bin_manager_cf.infrastructure.exception.AppException;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+import reactor.test.StepVerifier;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.*;
+
+class ListAgenciesServiceTest {
+
+    private AgencyRepository repo;
+    private SubtypeReadOnlyRepository subtypeRepo;
+    private ListAgenciesService service;
+
+    @BeforeEach
+    void setUp() {
+        repo = mock(AgencyRepository.class);
+        subtypeRepo = mock(SubtypeReadOnlyRepository.class);
+        service = new ListAgenciesService(repo, subtypeRepo);
+    }
+
+    @Test
+    void whenPaginationInvalidThenEmitInvalidData() {
+        StepVerifier.create(service.execute("01", null, null, -1, 0))
+                .expectErrorSatisfies(error -> {
+                    assertTrue(error instanceof AppException);
+                    AppException appException = (AppException) error;
+                    assertEquals(AppError.AGENCY_INVALID_DATA, appException.getError());
+                    assertTrue(appException.getMessage().contains("page"));
+                })
+                .verify();
+
+        verifyNoInteractions(repo, subtypeRepo);
+    }
+
+    @Test
+    void whenSubtypeNotProvidedThenListFromRepository() {
+        Agency agency = Agency.rehydrate("01", "001", "Agency", null, null, null, null,
+                null, null, null, null, null, null, null, null, null, "A", null, null, null);
+        when(repo.findAll(null, "A", "ag", 0, 20)).thenReturn(Flux.just(agency));
+
+        StepVerifier.create(service.execute(null, "A", "ag", 0, 20))
+                .expectNext(agency)
+                .verifyComplete();
+
+        verify(repo).findAll(null, "A", "ag", 0, 20);
+        verifyNoMoreInteractions(repo);
+        verifyNoInteractions(subtypeRepo);
+    }
+
+    @Test
+    void whenSubtypeNotFoundThenEmitError() {
+        when(subtypeRepo.existsByCode("01")).thenReturn(Mono.just(false));
+
+        StepVerifier.create(service.execute("01", "A", null, 0, 10))
+                .expectErrorSatisfies(error -> {
+                    assertTrue(error instanceof AppException);
+                    assertEquals(AppError.SUBTYPE_NOT_FOUND, ((AppException) error).getError());
+                })
+                .verify();
+
+        verify(subtypeRepo).existsByCode("01");
+        verifyNoInteractions(repo);
+    }
+
+    @Test
+    void whenSubtypeExistsThenDelegateToRepository() {
+        Agency agency = Agency.rehydrate("01", "001", "Agency", null, null, null, null,
+                null, null, null, null, null, null, null, null, null, "A", null, null, null);
+        when(subtypeRepo.existsByCode("01")).thenReturn(Mono.just(true));
+        when(repo.findAll("01", "I", null, 1, 5)).thenReturn(Flux.just(agency));
+
+        StepVerifier.create(service.execute("01", "I", null, 1, 5))
+                .expectNext(agency)
+                .verifyComplete();
+
+        verify(subtypeRepo).existsByCode("01");
+        verify(repo).findAll("01", "I", null, 1, 5);
+        verifyNoMoreInteractions(repo);
+    }
+}

--- a/src/test/java/com/credibanco/authorizer_catalog_bin_manager_cf/application/agency/use_case/UpdateAgencyServiceTest.java
+++ b/src/test/java/com/credibanco/authorizer_catalog_bin_manager_cf/application/agency/use_case/UpdateAgencyServiceTest.java
@@ -1,0 +1,123 @@
+package com.credibanco.authorizer_catalog_bin_manager_cf.application.agency.use_case;
+
+import com.credibanco.authorizer_catalog_bin_manager_cf.application.agency.port.outbound.AgencyRepository;
+import com.credibanco.authorizer_catalog_bin_manager_cf.application.agency.port.outbound.SubtypeReadOnlyRepository;
+import com.credibanco.authorizer_catalog_bin_manager_cf.domain.agency.Agency;
+import com.credibanco.authorizer_catalog_bin_manager_cf.infrastructure.exception.AppError;
+import com.credibanco.authorizer_catalog_bin_manager_cf.infrastructure.exception.AppException;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.reactivestreams.Publisher;
+import org.springframework.transaction.reactive.TransactionalOperator;
+import reactor.core.publisher.Mono;
+import reactor.test.StepVerifier;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.*;
+
+class UpdateAgencyServiceTest {
+
+    private AgencyRepository repo;
+    private SubtypeReadOnlyRepository subtypeRepo;
+    private TransactionalOperator txOperator;
+    private UpdateAgencyService service;
+
+    @BeforeEach
+    void setUp() {
+        repo = mock(AgencyRepository.class);
+        subtypeRepo = mock(SubtypeReadOnlyRepository.class);
+        txOperator = mock(TransactionalOperator.class);
+        service = new UpdateAgencyService(repo, subtypeRepo, txOperator);
+
+        when(txOperator.transactional(any(Publisher.class)))
+                .thenAnswer(invocation -> invocation.getArgument(0));
+    }
+
+    @Test
+    void whenSubtypeDoesNotExistThenEmitSubtypeNotFound() {
+        Agency updated = Agency.rehydrate("01", "001", "Agency", null, null, null, null,
+                null, null, null, null, null, null, null, null, null, "A", null, null, "tester");
+        when(subtypeRepo.existsByCode("01")).thenReturn(Mono.just(false));
+
+        StepVerifier.create(service.execute(updated))
+                .expectErrorSatisfies(error -> {
+                    assertTrue(error instanceof AppException);
+                    assertEquals(AppError.SUBTYPE_NOT_FOUND, ((AppException) error).getError());
+                })
+                .verify();
+
+        verify(subtypeRepo).existsByCode("01");
+        verifyNoInteractions(repo);
+    }
+
+    @Test
+    void whenAgencyDoesNotExistThenEmitNotFound() {
+        Agency updated = Agency.rehydrate("01", "001", "Agency", null, null, null, null,
+                null, null, null, null, null, null, null, null, null, "A", null, null, "tester");
+        when(subtypeRepo.existsByCode("01")).thenReturn(Mono.just(true));
+        when(repo.findByPk("01", "001")).thenReturn(Mono.empty());
+
+        StepVerifier.create(service.execute(updated))
+                .expectErrorSatisfies(error -> {
+                    assertTrue(error instanceof AppException);
+                    assertEquals(AppError.AGENCY_NOT_FOUND, ((AppException) error).getError());
+                })
+                .verify();
+
+        verify(subtypeRepo).existsByCode("01");
+        verify(repo).findByPk("01", "001");
+        verifyNoMoreInteractions(repo);
+    }
+
+    @Test
+    void whenDomainValidationFailsThenEmitInvalidData() {
+        Agency updated = Agency.rehydrate("01", "001", "Updated", null, null, null, null,
+                null, null, null, null, null, null, null, null, null, "A", null, null, "tester");
+        Agency current = spy(Agency.rehydrate("01", "001", "Current", null, null, null, null,
+                null, null, null, null, null, null, null, null, null, "A", null, null, "admin"));
+
+        when(subtypeRepo.existsByCode("01")).thenReturn(Mono.just(true));
+        when(repo.findByPk("01", "001")).thenReturn(Mono.just(current));
+        doThrow(new IllegalArgumentException("name es requerido"))
+                .when(current).updateBasics(
+                        anyString(), any(), any(), any(), any(), any(), any(), any(), any(), any(), any(), any(), any(), any(), any(), any(), any());
+
+        StepVerifier.create(service.execute(updated))
+                .expectErrorSatisfies(error -> {
+                    assertTrue(error instanceof AppException);
+                    AppException appException = (AppException) error;
+                    assertEquals(AppError.AGENCY_INVALID_DATA, appException.getError());
+                    assertEquals("name es requerido", appException.getMessage());
+                })
+                .verify();
+
+        verify(subtypeRepo).existsByCode("01");
+        verify(repo).findByPk("01", "001");
+        verifyNoMoreInteractions(repo);
+    }
+
+    @Test
+    void whenUpdateSucceedsThenPersistAndReturn() {
+        Agency updated = Agency.rehydrate("01", "001", "Agency", null, null, null, null,
+                null, null, null, null, null, null, null, null, null, "A", null, null, "tester");
+        Agency current = Agency.rehydrate("01", "001", "Current", null, null, null, null,
+                null, null, null, null, null, null, null, null, null, "A", null, null, "admin");
+        when(subtypeRepo.existsByCode("01")).thenReturn(Mono.just(true));
+        when(repo.findByPk("01", "001")).thenReturn(Mono.just(current));
+        when(repo.save(any(Agency.class))).thenAnswer(invocation -> Mono.just(invocation.getArgument(0)));
+
+        StepVerifier.create(service.execute(updated))
+                .assertNext(saved -> {
+                    assertEquals("Agency", saved.name());
+                    assertEquals("tester", saved.updatedBy());
+                })
+                .verifyComplete();
+
+        verify(subtypeRepo).existsByCode("01");
+        verify(repo).findByPk("01", "001");
+        verify(repo).save(any(Agency.class));
+        verifyNoMoreInteractions(repo);
+    }
+}


### PR DESCRIPTION
## Summary
- add unit tests for agency application services covering create, update, list, get, and status change flows using mocked repositories
- verify error handling scenarios to ensure domain and repository edge cases map to AppException codes

## Testing
- `mvn test` *(fails: unable to download org.springframework.boot:spring-boot-starter-parent:3.5.5 from Maven Central due to HTTP 403 in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e2833b5c84832e830977a566c777e9