### PR TITLE
Add comprehensive rule layer unit tests

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -45,16 +45,22 @@
             <version>1.18.40</version>
             <scope>provided</scope>
         </dependency>
-		<dependency>
-			<groupId>org.springframework.boot</groupId>
-			<artifactId>spring-boot-starter-test</artifactId>
-			<scope>test</scope>
-		</dependency>
-		<dependency>
-			<groupId>io.projectreactor</groupId>
-			<artifactId>reactor-test</artifactId>
-			<scope>test</scope>
-		</dependency>
+                <dependency>
+                        <groupId>org.springframework.boot</groupId>
+                        <artifactId>spring-boot-starter-test</artifactId>
+                        <scope>test</scope>
+                </dependency>
+                <dependency>
+                        <groupId>io.projectreactor</groupId>
+                        <artifactId>reactor-test</artifactId>
+                        <scope>test</scope>
+                </dependency>
+                <dependency>
+                        <groupId>org.mockito</groupId>
+                        <artifactId>mockito-inline</artifactId>
+                        <version>5.2.0</version>
+                        <scope>test</scope>
+                </dependency>
 
         <dependency>
             <groupId>org.springframework.boot</groupId>

--- a/src/test/java/com/credibanco/authorizer_catalog_bin_manager_cf/application/rule/use_case/ChangeValidationStatusServiceTest.java
+++ b/src/test/java/com/credibanco/authorizer_catalog_bin_manager_cf/application/rule/use_case/ChangeValidationStatusServiceTest.java
@@ -1,0 +1,97 @@
+package com.credibanco.authorizer_catalog_bin_manager_cf.application.rule.use_case;
+
+import com.credibanco.authorizer_catalog_bin_manager_cf.application.rule.port.outbound.ValidationRepository;
+import com.credibanco.authorizer_catalog_bin_manager_cf.domain.rule.Validation;
+import com.credibanco.authorizer_catalog_bin_manager_cf.domain.rule.ValidationDataType;
+import com.credibanco.authorizer_catalog_bin_manager_cf.infrastructure.exception.AppError;
+import com.credibanco.authorizer_catalog_bin_manager_cf.infrastructure.exception.AppException;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.transaction.reactive.TransactionalOperator;
+import reactor.core.publisher.Mono;
+import reactor.test.StepVerifier;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+class ChangeValidationStatusServiceTest {
+
+    private ValidationRepository repository;
+    private TransactionalOperator tx;
+    private ChangeValidationStatusService service;
+
+    @BeforeEach
+    void setUp() {
+        repository = mock(ValidationRepository.class);
+        tx = mock(TransactionalOperator.class);
+        service = new ChangeValidationStatusService(repository, tx);
+
+        when(tx.transactional(any(Mono.class))).thenAnswer(invocation -> invocation.getArgument(0));
+    }
+
+    @Test
+    void whenStatusInvalidReturnsAppException() {
+        StepVerifier.create(service.execute("CODE", "X", "user"))
+                .expectErrorSatisfies(error -> {
+                    assertTrue(error instanceof AppException);
+                    assertEquals(AppError.RULES_VALIDATION_INVALID_DATA, ((AppException) error).getError());
+                })
+                .verify();
+
+        verifyNoInteractions(repository);
+    }
+
+    @Test
+    void whenValidationNotFoundReturnsError() {
+        when(repository.findByCode("CODE")).thenReturn(Mono.empty());
+
+        StepVerifier.create(service.execute("CODE", "A", "user"))
+                .expectErrorSatisfies(error -> {
+                    assertTrue(error instanceof AppException);
+                    assertEquals(AppError.RULES_VALIDATION_NOT_FOUND, ((AppException) error).getError());
+                })
+                .verify();
+
+        verify(repository).findByCode("CODE");
+        verifyNoMoreInteractions(repository);
+    }
+
+    @Test
+    void whenDomainRejectsStatusReturnsAppException() {
+        Validation current = mock(Validation.class);
+        when(repository.findByCode("CODE")).thenReturn(Mono.just(current));
+        when(current.changeStatus("A", "user"))
+                .thenThrow(new IllegalArgumentException("bad"));
+
+        StepVerifier.create(service.execute("CODE", "A", "user"))
+                .expectErrorSatisfies(error -> {
+                    assertTrue(error instanceof AppException);
+                    assertEquals(AppError.RULES_VALIDATION_INVALID_DATA, ((AppException) error).getError());
+                })
+                .verify();
+
+        verify(repository).findByCode("CODE");
+        verifyNoMoreInteractions(repository);
+    }
+
+    @Test
+    void whenStatusValidSavesEntity() {
+        Validation current = Validation.createNew("CODE", "desc", ValidationDataType.TEXT, "creator");
+        when(repository.findByCode("CODE")).thenReturn(Mono.just(current));
+        when(repository.save(any(Validation.class))).thenAnswer(invocation -> Mono.just(invocation.getArgument(0)));
+
+        StepVerifier.create(service.execute("CODE", "I", "user"))
+                .assertNext(updated -> {
+                    assertEquals("I", updated.status());
+                    assertEquals("user", updated.updatedBy());
+                })
+                .verifyComplete();
+
+        verify(repository).findByCode("CODE");
+        verify(repository).save(any(Validation.class));
+        verifyNoMoreInteractions(repository);
+    }
+}
+

--- a/src/test/java/com/credibanco/authorizer_catalog_bin_manager_cf/application/rule/use_case/CreateValidationServiceTest.java
+++ b/src/test/java/com/credibanco/authorizer_catalog_bin_manager_cf/application/rule/use_case/CreateValidationServiceTest.java
@@ -1,0 +1,81 @@
+package com.credibanco.authorizer_catalog_bin_manager_cf.application.rule.use_case;
+
+import com.credibanco.authorizer_catalog_bin_manager_cf.application.rule.port.outbound.ValidationRepository;
+import com.credibanco.authorizer_catalog_bin_manager_cf.domain.rule.Validation;
+import com.credibanco.authorizer_catalog_bin_manager_cf.domain.rule.ValidationDataType;
+import com.credibanco.authorizer_catalog_bin_manager_cf.infrastructure.exception.AppError;
+import com.credibanco.authorizer_catalog_bin_manager_cf.infrastructure.exception.AppException;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.transaction.reactive.TransactionalOperator;
+import reactor.core.publisher.Mono;
+import reactor.test.StepVerifier;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+class CreateValidationServiceTest {
+
+    private ValidationRepository repository;
+    private TransactionalOperator tx;
+    private CreateValidationService service;
+
+    @BeforeEach
+    void setUp() {
+        repository = mock(ValidationRepository.class);
+        tx = mock(TransactionalOperator.class);
+        service = new CreateValidationService(repository, tx);
+
+        when(tx.transactional(any(Mono.class))).thenAnswer(invocation -> invocation.getArgument(0));
+    }
+
+    @Test
+    void whenValidationAlreadyExistsReturnsError() {
+        when(repository.existsByCode("CODE")).thenReturn(Mono.just(true));
+
+        StepVerifier.create(service.execute("CODE", "desc", ValidationDataType.BOOL, "me"))
+                .expectErrorSatisfies(error -> {
+                    assertTrue(error instanceof AppException);
+                    assertEquals(AppError.RULES_VALIDATION_ALREADY_EXISTS, ((AppException) error).getError());
+                })
+                .verify();
+
+        verify(repository).existsByCode("CODE");
+        verifyNoMoreInteractions(repository);
+    }
+
+    @Test
+    void whenDomainRejectsDataReturnsAppException() {
+        when(repository.existsByCode(" ")).thenReturn(Mono.just(false));
+
+        StepVerifier.create(service.execute(" ", "desc", ValidationDataType.TEXT, "user"))
+                .expectErrorSatisfies(error -> {
+                    assertTrue(error instanceof AppException);
+                    assertEquals(AppError.RULES_VALIDATION_INVALID_DATA, ((AppException) error).getError());
+                })
+                .verify();
+
+        verify(repository).existsByCode(" ");
+        verifyNoMoreInteractions(repository);
+    }
+
+    @Test
+    void whenValidDataPersistsValidation() {
+        when(repository.existsByCode("CODE")).thenReturn(Mono.just(false));
+        when(repository.save(any(Validation.class))).thenAnswer(invocation -> Mono.just(invocation.getArgument(0)));
+
+        StepVerifier.create(service.execute("CODE", "desc", ValidationDataType.NUMBER, "user"))
+                .assertNext(validation -> {
+                    assertEquals("CODE", validation.code());
+                    assertEquals(ValidationDataType.NUMBER, validation.dataType());
+                })
+                .verifyComplete();
+
+        verify(repository).existsByCode("CODE");
+        verify(repository).save(any(Validation.class));
+        verifyNoMoreInteractions(repository);
+    }
+}
+

--- a/src/test/java/com/credibanco/authorizer_catalog_bin_manager_cf/application/rule/use_case/GetValidationServiceTest.java
+++ b/src/test/java/com/credibanco/authorizer_catalog_bin_manager_cf/application/rule/use_case/GetValidationServiceTest.java
@@ -1,0 +1,56 @@
+package com.credibanco.authorizer_catalog_bin_manager_cf.application.rule.use_case;
+
+import com.credibanco.authorizer_catalog_bin_manager_cf.application.rule.port.outbound.ValidationRepository;
+import com.credibanco.authorizer_catalog_bin_manager_cf.domain.rule.Validation;
+import com.credibanco.authorizer_catalog_bin_manager_cf.domain.rule.ValidationDataType;
+import com.credibanco.authorizer_catalog_bin_manager_cf.infrastructure.exception.AppError;
+import com.credibanco.authorizer_catalog_bin_manager_cf.infrastructure.exception.AppException;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import reactor.core.publisher.Mono;
+import reactor.test.StepVerifier;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.*;
+
+class GetValidationServiceTest {
+
+    private ValidationRepository repository;
+    private GetValidationService service;
+
+    @BeforeEach
+    void setUp() {
+        repository = mock(ValidationRepository.class);
+        service = new GetValidationService(repository);
+    }
+
+    @Test
+    void whenValidationMissingThrowsException() {
+        when(repository.findByCode("VAL")).thenReturn(Mono.empty());
+
+        StepVerifier.create(service.execute("VAL"))
+                .expectErrorSatisfies(error -> {
+                    assertTrue(error instanceof AppException);
+                    assertEquals(AppError.RULES_VALIDATION_NOT_FOUND, ((AppException) error).getError());
+                })
+                .verify();
+
+        verify(repository).findByCode("VAL");
+        verifyNoMoreInteractions(repository);
+    }
+
+    @Test
+    void whenValidationExistsReturnsIt() {
+        Validation validation = Validation.createNew("VAL", "desc", ValidationDataType.BOOL, "tester");
+        when(repository.findByCode("VAL")).thenReturn(Mono.just(validation));
+
+        StepVerifier.create(service.execute("VAL"))
+                .expectNext(validation)
+                .verifyComplete();
+
+        verify(repository).findByCode("VAL");
+        verifyNoMoreInteractions(repository);
+    }
+}
+

--- a/src/test/java/com/credibanco/authorizer_catalog_bin_manager_cf/application/rule/use_case/ListRulesForSubtypeServiceTest.java
+++ b/src/test/java/com/credibanco/authorizer_catalog_bin_manager_cf/application/rule/use_case/ListRulesForSubtypeServiceTest.java
@@ -1,0 +1,67 @@
+package com.credibanco.authorizer_catalog_bin_manager_cf.application.rule.use_case;
+
+import com.credibanco.authorizer_catalog_bin_manager_cf.application.rule.port.outbound.ValidationMapRepository;
+import com.credibanco.authorizer_catalog_bin_manager_cf.domain.rule.ValidationMap;
+import com.credibanco.authorizer_catalog_bin_manager_cf.infrastructure.exception.AppError;
+import com.credibanco.authorizer_catalog_bin_manager_cf.infrastructure.exception.AppException;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import reactor.core.publisher.Flux;
+import reactor.test.StepVerifier;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.*;
+
+class ListRulesForSubtypeServiceTest {
+
+    private ValidationMapRepository mapRepository;
+    private ListRulesForSubtypeService service;
+
+    @BeforeEach
+    void setUp() {
+        mapRepository = mock(ValidationMapRepository.class);
+        service = new ListRulesForSubtypeService(mapRepository);
+    }
+
+    @Test
+    void whenPaginationInvalidReturnsError() {
+        StepVerifier.create(service.execute("SUB", "BIN", "A", -1, 10))
+                .expectErrorSatisfies(error -> {
+                    assertTrue(error instanceof AppException);
+                    assertEquals(AppError.RULES_MAP_INVALID_DATA, ((AppException) error).getError());
+                })
+                .verify();
+
+        StepVerifier.create(service.execute("SUB", "BIN", "A", 0, 0))
+                .expectError(AppException.class)
+                .verify();
+
+        verifyNoInteractions(mapRepository);
+    }
+
+    @Test
+    void whenStatusBlankReplacedWithNull() {
+        ValidationMap map = ValidationMap.createNew("SUB", "BIN", 1L, "SI", null, null, "user");
+        when(mapRepository.findResolved("SUB", "BIN", null, 0, 10)).thenReturn(Flux.just(map));
+
+        StepVerifier.create(service.execute("SUB", "BIN", " ", 0, 10))
+                .expectNext(map)
+                .verifyComplete();
+
+        verify(mapRepository).findResolved("SUB", "BIN", null, 0, 10);
+        verifyNoMoreInteractions(mapRepository);
+    }
+
+    @Test
+    void whenStatusProvidedDelegatesDirectly() {
+        when(mapRepository.findResolved("SUB", null, "I", 2, 20)).thenReturn(Flux.empty());
+
+        StepVerifier.create(service.execute("SUB", null, "I", 2, 20))
+                .verifyComplete();
+
+        verify(mapRepository).findResolved("SUB", null, "I", 2, 20);
+        verifyNoMoreInteractions(mapRepository);
+    }
+}
+

--- a/src/test/java/com/credibanco/authorizer_catalog_bin_manager_cf/application/rule/use_case/ListValidationsServiceTest.java
+++ b/src/test/java/com/credibanco/authorizer_catalog_bin_manager_cf/application/rule/use_case/ListValidationsServiceTest.java
@@ -1,0 +1,57 @@
+package com.credibanco.authorizer_catalog_bin_manager_cf.application.rule.use_case;
+
+import com.credibanco.authorizer_catalog_bin_manager_cf.application.rule.port.outbound.ValidationRepository;
+import com.credibanco.authorizer_catalog_bin_manager_cf.domain.rule.Validation;
+import com.credibanco.authorizer_catalog_bin_manager_cf.domain.rule.ValidationDataType;
+import com.credibanco.authorizer_catalog_bin_manager_cf.infrastructure.exception.AppError;
+import com.credibanco.authorizer_catalog_bin_manager_cf.infrastructure.exception.AppException;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import reactor.core.publisher.Flux;
+import reactor.test.StepVerifier;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.*;
+
+class ListValidationsServiceTest {
+
+    private ValidationRepository repository;
+    private ListValidationsService service;
+
+    @BeforeEach
+    void setUp() {
+        repository = mock(ValidationRepository.class);
+        service = new ListValidationsService(repository);
+    }
+
+    @Test
+    void whenPaginationInvalidReturnsError() {
+        StepVerifier.create(service.execute("A", null, -1, 10))
+                .expectErrorSatisfies(error -> {
+                    assertTrue(error instanceof AppException);
+                    assertEquals(AppError.RULES_VALIDATION_INVALID_DATA, ((AppException) error).getError());
+                })
+                .verify();
+
+        StepVerifier.create(service.execute("A", null, 0, 0))
+                .expectError(AppException.class)
+                .verify();
+
+        verifyNoInteractions(repository);
+    }
+
+    @Test
+    void whenPaginationValidDelegatesToRepository() {
+        Validation validation = Validation.createNew("V1", "desc", ValidationDataType.TEXT, "tester");
+        when(repository.findAll("A", "search", 1, 5)).thenReturn(Flux.just(validation));
+
+        StepVerifier.create(service.execute("A", "search", 1, 5))
+                .expectNext(validation)
+                .verifyComplete();
+
+        verify(repository).findAll("A", "search", 1, 5);
+        verifyNoMoreInteractions(repository);
+    }
+}
+

--- a/src/test/java/com/credibanco/authorizer_catalog_bin_manager_cf/application/rule/use_case/MapRuleServiceTest.java
+++ b/src/test/java/com/credibanco/authorizer_catalog_bin_manager_cf/application/rule/use_case/MapRuleServiceTest.java
@@ -1,0 +1,321 @@
+package com.credibanco.authorizer_catalog_bin_manager_cf.application.rule.use_case;
+
+import com.credibanco.authorizer_catalog_bin_manager_cf.application.rule.port.outbound.SubtypeReadOnlyRepository;
+import com.credibanco.authorizer_catalog_bin_manager_cf.application.rule.port.outbound.ValidationMapRepository;
+import com.credibanco.authorizer_catalog_bin_manager_cf.application.rule.port.outbound.ValidationRepository;
+import com.credibanco.authorizer_catalog_bin_manager_cf.domain.rule.Validation;
+import com.credibanco.authorizer_catalog_bin_manager_cf.domain.rule.ValidationDataType;
+import com.credibanco.authorizer_catalog_bin_manager_cf.domain.rule.ValidationMap;
+import com.credibanco.authorizer_catalog_bin_manager_cf.infrastructure.exception.AppError;
+import com.credibanco.authorizer_catalog_bin_manager_cf.infrastructure.exception.AppException;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.transaction.ReactiveTransaction;
+import org.springframework.transaction.reactive.TransactionalOperator;
+import reactor.core.publisher.Mono;
+import reactor.test.StepVerifier;
+
+import java.time.OffsetDateTime;
+import java.util.function.Function;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+class MapRuleServiceTest {
+
+    private ValidationRepository validations;
+    private ValidationMapRepository maps;
+    private SubtypeReadOnlyRepository subtypes;
+    private TransactionalOperator tx;
+    private MapRuleService service;
+
+    @BeforeEach
+    void setUp() {
+        validations = mock(ValidationRepository.class);
+        maps = mock(ValidationMapRepository.class);
+        subtypes = mock(SubtypeReadOnlyRepository.class);
+        tx = mock(TransactionalOperator.class);
+        service = new MapRuleService(validations, maps, subtypes, tx);
+
+        when(tx.transactional(any(Mono.class))).thenAnswer(invocation -> invocation.getArgument(0));
+        when(tx.execute(any())).thenAnswer(invocation -> {
+            @SuppressWarnings("unchecked")
+            Function<ReactiveTransaction, Mono<ValidationMap>> callback = invocation.getArgument(0);
+            return Mono.defer(() -> callback.apply(null));
+        });
+    }
+
+    @Test
+    void whenValueNullReturnsError() {
+        StepVerifier.create(service.attach("S", "B", "VAL", null, "user"))
+                .expectErrorSatisfies(error -> {
+                    assertTrue(error instanceof AppException);
+                    assertEquals(AppError.RULES_MAP_INVALID_DATA, ((AppException) error).getError());
+                })
+                .verify();
+
+        verifyNoInteractions(subtypes, validations, maps);
+    }
+
+    @Test
+    void whenSubtypeMissingReturnsError() {
+        when(subtypes.existsByCode("S")).thenReturn(Mono.just(false));
+
+        StepVerifier.create(service.attach("S", "B", "VAL", "SI", "user"))
+                .expectErrorSatisfies(error -> {
+                    assertTrue(error instanceof AppException);
+                    assertEquals(AppError.SUBTYPE_NOT_FOUND, ((AppException) error).getError());
+                })
+                .verify();
+
+        verify(subtypes).existsByCode("S");
+        verifyNoMoreInteractions(subtypes, validations, maps);
+    }
+
+    @Test
+    void whenBinPairMissingReturnsError() {
+        when(subtypes.existsByCode("S")).thenReturn(Mono.just(true));
+        when(subtypes.existsByCodeAndBinEfectivo("S", "B")).thenReturn(Mono.just(false));
+
+        StepVerifier.create(service.attach("S", "B", "VAL", "SI", "user"))
+                .expectErrorSatisfies(error -> {
+                    assertTrue(error instanceof AppException);
+                    assertEquals(AppError.BIN_NOT_FOUND, ((AppException) error).getError());
+                })
+                .verify();
+
+        verify(subtypes).existsByCode("S");
+        verify(subtypes).existsByCodeAndBinEfectivo("S", "B");
+        verifyNoMoreInteractions(subtypes);
+        verifyNoInteractions(validations, maps);
+    }
+
+    @Test
+    void whenValidationMissingReturnsError() {
+        activeSubtype();
+        when(validations.findByCode("VAL")).thenReturn(Mono.empty());
+
+        StepVerifier.create(service.attach("S", "B", "VAL", "SI", "user"))
+                .expectErrorSatisfies(error -> {
+                    assertTrue(error instanceof AppException);
+                    assertEquals(AppError.RULES_VALIDATION_NOT_FOUND, ((AppException) error).getError());
+                })
+                .verify();
+
+        verify(validations).findByCode("VAL");
+        verifyNoMoreInteractions(validations);
+    }
+
+    @Test
+    void whenValidationNotActiveReturnsError() {
+        activeSubtype();
+        Validation validation = Validation.rehydrate(1L, "VAL", "desc", ValidationDataType.BOOL,
+                "I", null, null, OffsetDateTime.now(), OffsetDateTime.now(), "user");
+        when(validations.findByCode("VAL")).thenReturn(Mono.just(validation));
+
+        StepVerifier.create(service.attach("S", "B", "VAL", "SI", "user"))
+                .expectErrorSatisfies(error -> {
+                    assertTrue(error instanceof AppException);
+                    assertEquals(AppError.RULES_MAP_INVALID_DATA, ((AppException) error).getError());
+                })
+                .verify();
+    }
+
+    @Test
+    void whenValueCannotBeCoercedReturnsError() {
+        activeSubtype();
+        Validation validation = activeValidation(ValidationDataType.BOOL);
+        when(validations.findByCode("VAL")).thenReturn(Mono.just(validation));
+
+        StepVerifier.create(service.attach("S", "B", "VAL", "MAYBE", "user"))
+                .expectErrorSatisfies(error -> {
+                    assertTrue(error instanceof AppException);
+                    assertEquals(AppError.RULES_MAP_INVALID_DATA, ((AppException) error).getError());
+                })
+                .verify();
+    }
+
+    @Test
+    void whenMappingAlreadyExistsReturnsError() {
+        activeSubtype();
+        Validation validation = activeValidation(ValidationDataType.TEXT);
+        when(validations.findByCode("VAL")).thenReturn(Mono.just(validation));
+        ValidationMap existing = ValidationMap.createNew("S", "B", 1L, null, null, "value", "user");
+        when(maps.findByNaturalKey("S", "B", validation.validationId()))
+                .thenReturn(Mono.just(existing));
+
+        StepVerifier.create(service.attach("S", "B", "VAL", "text", "user"))
+                .expectErrorSatisfies(error -> {
+                    assertTrue(error instanceof AppException);
+                    assertEquals(AppError.RULES_MAP_ALREADY_EXISTS, ((AppException) error).getError());
+                })
+                .verify();
+    }
+
+    @Test
+    void whenBoolValueValidSavesMapping() {
+        activeSubtype();
+        Validation validation = activeValidation(ValidationDataType.BOOL);
+        when(validations.findByCode("VAL")).thenReturn(Mono.just(validation));
+        when(maps.findByNaturalKey("S", "B", validation.validationId())).thenReturn(Mono.empty());
+        when(maps.save(any(ValidationMap.class))).thenAnswer(invocation -> Mono.just(invocation.getArgument(0)));
+
+        StepVerifier.create(service.attach("S", "B", "VAL", "true", "user"))
+                .assertNext(saved -> {
+                    assertEquals("SI", saved.valueFlag());
+                    assertNull(saved.valueNum());
+                    assertNull(saved.valueText());
+                })
+                .verifyComplete();
+
+        verify(maps).findByNaturalKey("S", "B", validation.validationId());
+        verify(maps).save(any(ValidationMap.class));
+    }
+
+    @Test
+    void whenNumberValueValidSavesMapping() {
+        activeSubtype();
+        Validation validation = activeValidation(ValidationDataType.NUMBER);
+        when(validations.findByCode("VAL")).thenReturn(Mono.just(validation));
+        when(maps.findByNaturalKey("S", "B", validation.validationId())).thenReturn(Mono.empty());
+        when(maps.save(any(ValidationMap.class))).thenAnswer(invocation -> Mono.just(invocation.getArgument(0)));
+
+        StepVerifier.create(service.attach("S", "B", "VAL", "123.5", "user"))
+                .assertNext(saved -> {
+                    assertEquals(123.5, saved.valueNum());
+                    assertNull(saved.valueFlag());
+                    assertNull(saved.valueText());
+                })
+                .verifyComplete();
+    }
+
+    @Test
+    void whenNumberCannotBeCoercedReturnsError() {
+        activeSubtype();
+        Validation validation = activeValidation(ValidationDataType.NUMBER);
+        when(validations.findByCode("VAL")).thenReturn(Mono.just(validation));
+
+        StepVerifier.create(service.attach("S", "B", "VAL", "abc", "user"))
+                .expectErrorSatisfies(error -> {
+                    assertTrue(error instanceof AppException);
+                    assertEquals(AppError.RULES_MAP_INVALID_DATA, ((AppException) error).getError());
+                })
+                .verify();
+    }
+
+    @Test
+    void whenTextValueValidSavesMapping() {
+        activeSubtype();
+        Validation validation = activeValidation(ValidationDataType.TEXT);
+        when(validations.findByCode("VAL")).thenReturn(Mono.just(validation));
+        when(maps.findByNaturalKey("S", "B", validation.validationId())).thenReturn(Mono.empty());
+        when(maps.save(any(ValidationMap.class))).thenAnswer(invocation -> Mono.just(invocation.getArgument(0)));
+
+        StepVerifier.create(service.attach("S", "B", "VAL", 42, "user"))
+                .assertNext(saved -> {
+                    assertEquals("42", saved.valueText());
+                    assertNull(saved.valueFlag());
+                    assertNull(saved.valueNum());
+                })
+                .verifyComplete();
+    }
+
+    @Test
+    void whenTextBlankReturnsError() {
+        activeSubtype();
+        Validation validation = activeValidation(ValidationDataType.TEXT);
+        when(validations.findByCode("VAL")).thenReturn(Mono.just(validation));
+
+        StepVerifier.create(service.attach("S", "B", "VAL", " ", "user"))
+                .expectErrorSatisfies(error -> {
+                    assertTrue(error instanceof AppException);
+                    assertEquals(AppError.RULES_MAP_INVALID_DATA, ((AppException) error).getError());
+                })
+                .verify();
+    }
+
+    @Test
+    void changeStatusWhenStatusInvalidReturnsError() {
+        StepVerifier.create(service.changeStatus("S", "B", "VAL", "X", "user"))
+                .expectErrorSatisfies(error -> {
+                    assertTrue(error instanceof AppException);
+                    assertEquals(AppError.RULES_MAP_INVALID_DATA, ((AppException) error).getError());
+                })
+                .verify();
+
+        verifyNoInteractions(validations, maps);
+    }
+
+    @Test
+    void changeStatusWhenValidationMissingReturnsError() {
+        when(validations.findByCode("VAL")).thenReturn(Mono.empty());
+
+        StepVerifier.create(service.changeStatus("S", "B", "VAL", "A", "user"))
+                .expectErrorSatisfies(error -> {
+                    assertTrue(error instanceof AppException);
+                    assertEquals(AppError.RULES_VALIDATION_NOT_FOUND, ((AppException) error).getError());
+                })
+                .verify();
+    }
+
+    @Test
+    void changeStatusWhenMappingMissingReturnsError() {
+        Validation validation = activeValidation(ValidationDataType.BOOL);
+        when(validations.findByCode("VAL")).thenReturn(Mono.just(validation));
+        when(maps.findByNaturalKey("S", "B", validation.validationId())).thenReturn(Mono.empty());
+
+        StepVerifier.create(service.changeStatus("S", "B", "VAL", "A", "user"))
+                .expectErrorSatisfies(error -> {
+                    assertTrue(error instanceof AppException);
+                    assertEquals(AppError.RULES_MAP_NOT_FOUND, ((AppException) error).getError());
+                })
+                .verify();
+    }
+
+    @Test
+    void changeStatusWhenDomainRejectsStatusReturnsError() {
+        Validation validation = activeValidation(ValidationDataType.TEXT);
+        when(validations.findByCode("VAL")).thenReturn(Mono.just(validation));
+        ValidationMap mapping = mock(ValidationMap.class);
+        when(maps.findByNaturalKey("S", "B", validation.validationId())).thenReturn(Mono.just(mapping));
+        when(mapping.changeStatus("I", "user")).thenThrow(new IllegalArgumentException("bad"));
+
+        StepVerifier.create(service.changeStatus("S", "B", "VAL", "I", "user"))
+                .expectErrorSatisfies(error -> {
+                    assertTrue(error instanceof AppException);
+                    assertEquals(AppError.RULES_MAP_INVALID_DATA, ((AppException) error).getError());
+                })
+                .verify();
+    }
+
+    @Test
+    void changeStatusWhenValidSavesMapping() {
+        Validation validation = activeValidation(ValidationDataType.BOOL);
+        when(validations.findByCode("VAL")).thenReturn(Mono.just(validation));
+        ValidationMap mapping = ValidationMap.createNew("S", "B", validation.validationId(), "SI", null, null, "user");
+        when(maps.findByNaturalKey("S", "B", validation.validationId())).thenReturn(Mono.just(mapping));
+        when(maps.save(any(ValidationMap.class))).thenAnswer(invocation -> Mono.just(invocation.getArgument(0)));
+
+        StepVerifier.create(service.changeStatus("S", "B", "VAL", "I", "user"))
+                .assertNext(updated -> {
+                    assertEquals("I", updated.status());
+                    assertEquals("user", updated.updatedBy());
+                })
+                .verifyComplete();
+
+        verify(maps).save(any(ValidationMap.class));
+    }
+
+    private void activeSubtype() {
+        when(subtypes.existsByCode("S")).thenReturn(Mono.just(true));
+        when(subtypes.existsByCodeAndBinEfectivo("S", "B")).thenReturn(Mono.just(true));
+    }
+
+    private Validation activeValidation(ValidationDataType type) {
+        return Validation.rehydrate(1L, "VAL", "desc", type, "A",
+                OffsetDateTime.now().minusDays(1), OffsetDateTime.now().plusDays(1),
+                OffsetDateTime.now().minusDays(2), OffsetDateTime.now().minusDays(1), "user");
+    }
+}
+

--- a/src/test/java/com/credibanco/authorizer_catalog_bin_manager_cf/application/rule/use_case/UpdateValidationServiceTest.java
+++ b/src/test/java/com/credibanco/authorizer_catalog_bin_manager_cf/application/rule/use_case/UpdateValidationServiceTest.java
@@ -1,0 +1,80 @@
+package com.credibanco.authorizer_catalog_bin_manager_cf.application.rule.use_case;
+
+import com.credibanco.authorizer_catalog_bin_manager_cf.application.rule.port.outbound.ValidationRepository;
+import com.credibanco.authorizer_catalog_bin_manager_cf.domain.rule.Validation;
+import com.credibanco.authorizer_catalog_bin_manager_cf.domain.rule.ValidationDataType;
+import com.credibanco.authorizer_catalog_bin_manager_cf.infrastructure.exception.AppError;
+import com.credibanco.authorizer_catalog_bin_manager_cf.infrastructure.exception.AppException;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import reactor.core.publisher.Mono;
+import reactor.test.StepVerifier;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+class UpdateValidationServiceTest {
+
+    private ValidationRepository repository;
+    private UpdateValidationService service;
+
+    @BeforeEach
+    void setUp() {
+        repository = mock(ValidationRepository.class);
+        service = new UpdateValidationService(repository);
+    }
+
+    @Test
+    void whenValidationMissingThrowsException() {
+        when(repository.findByCode("CODE")).thenReturn(Mono.empty());
+
+        StepVerifier.create(service.execute("CODE", "desc", "me"))
+                .expectErrorSatisfies(error -> {
+                    assertTrue(error instanceof AppException);
+                    assertEquals(AppError.RULES_VALIDATION_NOT_FOUND, ((AppException) error).getError());
+                })
+                .verify();
+
+        verify(repository).findByCode("CODE");
+        verifyNoMoreInteractions(repository);
+    }
+
+    @Test
+    void whenDomainRejectsUpdateReturnsAppException() {
+        Validation current = mock(Validation.class);
+        when(repository.findByCode("CODE")).thenReturn(Mono.just(current));
+        when(current.updateBasics("desc", "me"))
+                .thenThrow(new IllegalArgumentException("bad"));
+
+        StepVerifier.create(service.execute("CODE", "desc", "me"))
+                .expectErrorSatisfies(error -> {
+                    assertTrue(error instanceof AppException);
+                    assertEquals(AppError.RULES_VALIDATION_INVALID_DATA, ((AppException) error).getError());
+                })
+                .verify();
+
+        verify(repository).findByCode("CODE");
+        verifyNoMoreInteractions(repository);
+    }
+
+    @Test
+    void whenUpdateValidSavesEntity() {
+        Validation current = Validation.createNew("CODE", "desc", ValidationDataType.TEXT, "creator");
+        when(repository.findByCode("CODE")).thenReturn(Mono.just(current));
+        when(repository.save(any(Validation.class))).thenAnswer(invocation -> Mono.just(invocation.getArgument(0)));
+
+        StepVerifier.create(service.execute("CODE", "new desc", "user"))
+                .assertNext(updated -> {
+                    assertEquals("CODE", updated.code());
+                    assertEquals("user", updated.updatedBy());
+                })
+                .verifyComplete();
+
+        verify(repository).findByCode("CODE");
+        verify(repository).save(any(Validation.class));
+        verifyNoMoreInteractions(repository);
+    }
+}
+


### PR DESCRIPTION
## Summary
- add mockito-inline as a test dependency to allow mocking final records in the rule layer tests
- create unit tests for rule validation CRUD use cases covering success and error scenarios with mocked repositories
- add extensive MapRuleService tests to exercise mapping workflows, coercion helpers, and status changes

## Testing
- `mvn test` *(fails: Maven wrapper cannot download binaries from Maven Central in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e28aee3b28832e9350454ec4bbed66