### PR TITLE
Fix actor resolver method overload ambiguity

### DIFF
--- a/src/main/java/com/credibanco/authorizer_catalog_bin_manager_cf/infrastructure/port/inbound/http/common/RequestActorResolver.java
+++ b/src/main/java/com/credibanco/authorizer_catalog_bin_manager_cf/infrastructure/port/inbound/http/common/RequestActorResolver.java
@@ -16,14 +16,14 @@ public class RequestActorResolver {
     private final ActorProvider actorProvider;
 
     public Mono<ActorResolution> resolve(ServerRequest request, String bodyUser, String operation) {
-        return resolve(request, operation, bodyUser);
+        return resolveCandidate(request, operation, bodyUser);
     }
 
     public Mono<ActorResolution> resolve(ServerRequest request, String operation) {
-        return resolve(request, operation, null);
+        return resolveCandidate(request, operation, null);
     }
 
-    private Mono<ActorResolution> resolve(ServerRequest request, String operation, String candidate) {
+    private Mono<ActorResolution> resolveCandidate(ServerRequest request, String operation, String candidate) {
         return Mono.defer(() -> Mono.justOrEmpty(normalize(candidate))
                         .map(ActorResolution::fromBody)
                         .switchIfEmpty(Mono.justOrEmpty(normalize(request.headers().firstHeader("X-User")))


### PR DESCRIPTION
## Summary
- rename the private helper method in `RequestActorResolver` to avoid conflicting overloads
- update public methods to call the renamed helper

## Testing
- `./mvnw -q -DskipTests compile` *(fails: wget cannot fetch dependencies in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e544c64c28832eb9189b95e09d8174