### PR TITLE
Add trusted certificate support for JWKS retrieval

### DIFF
--- a/src/main/java/com/credibanco/authorizer_catalog_bin_manager_cf/infrastructure/config/security/SecurityConfig.java
+++ b/src/main/java/com/credibanco/authorizer_catalog_bin_manager_cf/infrastructure/config/security/SecurityConfig.java
@@ -1,5 +1,7 @@
 package com.credibanco.authorizer_catalog_bin_manager_cf.infrastructure.config.security;
 
+import io.netty.handler.ssl.SslContext;
+import io.netty.handler.ssl.SslContextBuilder;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
@@ -24,13 +26,23 @@ import org.springframework.security.web.server.authentication.AuthenticationWebF
 import org.springframework.security.web.server.authentication.DelegatingServerAuthenticationConverter;
 import org.springframework.security.web.server.authentication.ServerAuthenticationConverter;
 import org.springframework.security.web.server.util.matcher.ServerWebExchangeMatchers;
+import org.springframework.http.client.reactive.ReactorClientHttpConnector;
 import org.springframework.util.StringUtils;
+import org.springframework.web.reactive.function.client.WebClient;
 import reactor.core.publisher.Mono;
+import reactor.netty.http.client.HttpClient;
 
+import java.io.InputStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.security.KeyStore;
+import java.security.cert.Certificate;
+import java.security.cert.CertificateFactory;
 import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
+import javax.net.ssl.TrustManagerFactory;
 
 @Configuration
 @EnableReactiveMethodSecurity
@@ -45,6 +57,9 @@ public class SecurityConfig {
 
     @Value("${internal.jwt.required-audience}")
     private String requiredAudience;          // catalog-api
+
+    @Value("${internal.jwt.jwk.trusted-cert-path:}")
+    private String jwkTrustedCertificatePath;
 
     @Bean
     public SecurityWebFilterChain springSecurityFilterChain(ServerHttpSecurity http,
@@ -125,7 +140,10 @@ public class SecurityConfig {
      */
     @Bean
     public ReactiveJwtDecoder jwtDecoder() {
-        NimbusReactiveJwtDecoder decoder = NimbusReactiveJwtDecoder.withJwkSetUri(jwkSetUri).build();
+        NimbusReactiveJwtDecoder decoder = NimbusReactiveJwtDecoder
+                .withJwkSetUri(jwkSetUri)
+                .webClient(buildJwkWebClient())
+                .build();
 
         OAuth2TokenValidator<Jwt> defaults = JwtValidators.createDefault(); // exp/nbf, etc.
 
@@ -150,5 +168,46 @@ public class SecurityConfig {
         return decoder;
     }
 
-    
+    private WebClient buildJwkWebClient() {
+        HttpClient httpClient = HttpClient.create();
+
+        if (StringUtils.hasText(jwkTrustedCertificatePath)) {
+            try {
+                httpClient = httpClient.secure(ssl -> ssl.sslContext(buildSslContext(jwkTrustedCertificatePath)));
+            } catch (Exception ex) {
+                throw new IllegalStateException("Failed to initialize SSL context for JWK requests", ex);
+            }
+        }
+
+        return WebClient.builder()
+                .clientConnector(new ReactorClientHttpConnector(httpClient))
+                .build();
+    }
+
+    private SslContext buildSslContext(String certificatePath) throws Exception {
+        Path path = Path.of(certificatePath);
+        if (!Files.exists(path)) {
+            throw new IllegalArgumentException("Certificate file does not exist: " + certificatePath);
+        }
+
+        KeyStore keyStore = KeyStore.getInstance(KeyStore.getDefaultType());
+        keyStore.load(null);
+
+        CertificateFactory certificateFactory = CertificateFactory.getInstance("X.509");
+        try (InputStream inputStream = Files.newInputStream(path)) {
+            int index = 0;
+            for (Certificate certificate : certificateFactory.generateCertificates(inputStream)) {
+                keyStore.setCertificateEntry("cert-" + index++, certificate);
+            }
+        }
+
+        TrustManagerFactory trustManagerFactory = TrustManagerFactory.getInstance(TrustManagerFactory.getDefaultAlgorithm());
+        trustManagerFactory.init(keyStore);
+
+        return SslContextBuilder.forClient()
+                .trustManager(trustManagerFactory)
+                .build();
+    }
+
+
 }

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -20,3 +20,5 @@ server.port=8086
 spring.security.oauth2.resourceserver.jwt.jwk-set-uri=http://localhost:8083/internal/.well-known/jwks.json
 internal.jwt.expected-issuer=authorizer-gateway
 internal.jwt.required-audience=catalog-api
+# Ruta opcional a un certificado PEM (CA o certificado del gateway) para confiar en el JWKS remoto
+internal.jwt.jwk.trusted-cert-path=


### PR DESCRIPTION
## Summary
- configure the reactive JWT decoder to use a Reactor Netty client that can trust a custom PEM certificate when fetching the gateway JWKS
- document the new `internal.jwt.jwk.trusted-cert-path` property for deployments that require a custom trust store

## Testing
- `./mvnw -q test` *(fails: unable to download Maven distribution in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e55c91c728832e82d958d97dd76a65