### PR TITLE
Add extra coverage for NullOrBlankToNullIntegerDeserializer

### DIFF
--- a/src/test/java/com/credibanco/authorizer_catalog_bin_manager_cf/infrastructure/jackson/NullOrBlankToNullIntegerDeserializerTest.java
+++ b/src/test/java/com/credibanco/authorizer_catalog_bin_manager_cf/infrastructure/jackson/NullOrBlankToNullIntegerDeserializerTest.java
@@ -3,11 +3,21 @@ package com.credibanco.authorizer_catalog_bin_manager_cf.infrastructure.jackson;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.exc.MismatchedInputException;
 import com.fasterxml.jackson.databind.module.SimpleModule;
+import com.fasterxml.jackson.core.JsonToken;
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.databind.DeserializationContext;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 class NullOrBlankToNullIntegerDeserializerTest {
 
@@ -53,5 +63,19 @@ class NullOrBlankToNullIntegerDeserializerTest {
                 .isInstanceOf(MismatchedInputException.class);
         assertThatThrownBy(() -> mapper.readValue("{}", Integer.class))
                 .isInstanceOf(MismatchedInputException.class);
+    }
+
+    @Test
+    void returnsNullWhenParserTextIsNull() throws Exception {
+        JsonParser parser = Mockito.mock(JsonParser.class);
+        DeserializationContext context = Mockito.mock(DeserializationContext.class);
+
+        when(parser.currentToken()).thenReturn(JsonToken.VALUE_STRING);
+        when(parser.getText()).thenReturn(null);
+
+        Integer value = new NullOrBlankToNullIntegerDeserializer().deserialize(parser, context);
+
+        assertThat(value).isNull();
+        verify(context, never()).reportInputMismatch(eq(Integer.class), anyString());
     }
 }


### PR DESCRIPTION
## Summary
- add a Mockito-based unit test to cover the null parser text path in `NullOrBlankToNullIntegerDeserializer`

## Testing
- ./mvnw test


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691f8bbb5cb08330b4bfb7d12f31403e)